### PR TITLE
Prevent pm2 reload on image cache update

### DIFF
--- a/server/ecosystem.config.js
+++ b/server/ecosystem.config.js
@@ -4,8 +4,8 @@ module.exports = {
             name: 'tams-club-cal-server',
             script: 'src/app.js',
             watch: '.',
-            watch_delay: 1000,
-            ignore_watch: ['node_modules'],
+            watch_delay: 5000,
+            ignore_watch: ['node_modules', 'src/cache'],
         },
     ],
     env: {


### PR DESCRIPTION
PM2 restarts based on the `server/ecosystem.config.js` file, but after adding the image cache, I forgot that it would restart when an image is cached. Therefore, it was restarting upon a call to fetch images and creating the following error: `upstream prematurely closed connection while reading response header from upstream`. This was resolved by adding the `src/cache` folder to the `ignore_watch` field.