### PR TITLE
Don't add event to null list

### DIFF
--- a/client/src/redux/reducers/data.js
+++ b/client/src/redux/reducers/data.js
@@ -45,6 +45,8 @@ export default function data(state = initialState, action) {
             };
         }
         case ADD_EVENT: {
+            if (state.eventList === null) return state;
+            
             const { event } = action.payload;
             var eventList = [...state.eventList];
             eventList.push(event);


### PR DESCRIPTION
### Description

This simple fix adds an if statement to the ADD_EVENT action that will not do anything if the eventList is null. The eventList will then be fetched when the events list is loaded, and the frontend does not need to update redux when adding an event (if the home page wasn't loaded prior to adding the event).

### Fixes #221 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md)
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request
