### PR TITLE
When Event is added, the object ID is returned and stored

### DIFF
--- a/client/src/functions/api.js
+++ b/client/src/functions/api.js
@@ -40,9 +40,11 @@ async function postEvent(event, id = null) {
             body: JSON.stringify(event),
             headers: { 'Content-Type': 'application/json' },
         });
-        return res.status;
+        const jsonData = await res.json();
+        return { status: res.status, id: jsonData.id };
     } catch (error) {
         console.dir(error);
+        return { status: 400, id: null };
     }
 }
 
@@ -89,12 +91,17 @@ async function postClub(club, id = null) {
     }
 
     var update = id !== undefined && id !== null ? `?update=true&id=${id}` : '';
-    const res = await fetch(`${config.backend}/add-club${update}`, {
-        method: 'POST',
-        body: data,
-    });
-    const jsonData = await res.json();
-    return { status: res.status, id: jsonData.id };
+    try {
+        const res = await fetch(`${config.backend}/add-club${update}`, {
+            method: 'POST',
+            body: data,
+        });
+        const jsonData = await res.json();
+        return { status: res.status, id: jsonData.id };
+    } catch (error) {
+        console.dir(error);
+        return { status: 400, id: null };
+    }
 }
 
 /**

--- a/client/src/pages/Add.js
+++ b/client/src/pages/Add.js
@@ -75,10 +75,12 @@ class Add extends React.Component {
             this.state.description,
             this.state.addedBy
         );
-        const status = await postEvent(newEvent);
+        const res = await postEvent(newEvent);
 
-        if (status === 200) {
+        if (res.status === 200) {
+            newEvent.objId = res.id;
             this.props.addEvent(newEvent);
+            
             this.setState({
                 name: '',
                 clubName: '',

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -124,9 +124,11 @@ app.get('/event-list', async (req, res, next) => {
 });
 
 app.post('/add-event', async (req, res, next) => {
-    if (req.query.update === 'true') updateEvent(req.body, req.query.id);
-    else addEvent(req.body);
-    res.sendStatus(200);
+    var id = null;
+    if (req.query.update === 'true') id = await updateEvent(req.body, req.query.id);
+    else id = await addEvent(req.body);
+    res.status(200);
+    res.send({ id });
 });
 
 app.post('/add-volunteering', async (req, res, next) => {

--- a/server/src/database.js
+++ b/server/src/database.js
@@ -103,6 +103,7 @@ async function addEvent(event) {
             editedBy: [],
             description: event.description,
         });
+        return objId;
     } catch (error) {
         console.dir(error);
     }
@@ -136,6 +137,7 @@ async function updateEvent(event, id) {
                 },
             }
         );
+        return id;
     } catch (error) {
         console.dir(error);
     }
@@ -211,6 +213,7 @@ async function updateClub(club, id) {
                 },
             }
         );
+        return id;
     } catch (error) {
         console.dir(error);
     }


### PR DESCRIPTION
### Description

The new event will be added into the Redux store **with** an object ID, meaning that it won't break the events page LOL. We, however, do need to add an "invalid club" popup element if the ID is bad instead of just crashing.

### Fixes #220 and fixes #163 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md)
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
