### PR TITLE
You can now change advised/independent club statuses

### DIFF
--- a/client/src/components/ClubCard.js
+++ b/client/src/components/ClubCard.js
@@ -16,8 +16,8 @@ class ClubCard extends React.Component {
                         alt="club image"
                     ></img>
                 </div>
-                <div className={'club-card-type' + (this.props.club.advised != 'true' ? ' club-card-independent' : '')}>
-                    {this.props.club.advised == 'true' ? 'Advised' : 'Independent'}
+                <div className={'club-card-type' + (!this.props.club.advised ? ' club-card-independent' : '')}>
+                    {this.props.club.advised ? 'Advised' : 'Independent'}
                 </div>
                 <div className="club-card-name">{this.props.club.name}</div>
                 {/* TODO: Extract icons to seperate component */}

--- a/client/src/components/ClubPopup.js
+++ b/client/src/components/ClubPopup.js
@@ -160,6 +160,10 @@ class ClubPopup extends React.Component {
         return invalid;
     };
 
+    changeAdvised = () => {
+        this.setState({ advised: !this.state.advised });
+    };
+
     handleInputChange = (event) => {
         const target = event.target;
         this.setState({ [target.name]: target.value });
@@ -353,15 +357,22 @@ class ClubPopup extends React.Component {
                         ></ImageUpload>
                     </div>
                     <div className="club-popup-edit-bottom">
-                        <input
-                            name="name"
-                            className="line-in club-popup-name-input"
-                            type="text"
-                            placeholder="Club name..."
-                            value={this.state.name}
-                            onChange={this.handleInputChange}
-                        ></input>
-                        <br />
+                        <div className="club-popup-name-advised-div">
+                            <input
+                                name="name"
+                                className="line-in club-popup-name-input"
+                                type="text"
+                                placeholder="Club name..."
+                                value={this.state.name}
+                                onChange={this.handleInputChange}
+                            ></input>
+                            <ActionButton
+                                className={isActive('club-popup-advised club-popup-advised-edit', this.state.advised)}
+                                onClick={this.changeAdvised}
+                            >
+                                {this.state.advised ? 'Advised' : 'Independent'}
+                            </ActionButton>
+                        </div>
                         <label htmlFor="description">Description</label>
                         <br />
                         <textarea

--- a/client/src/components/ClubPopup.scss
+++ b/client/src/components/ClubPopup.scss
@@ -152,9 +152,22 @@
     padding: 0.75rem;
 }
 
+.club-popup-name-advised-div {
+    display: flex;
+    flex-direction: row;
+    justify-content: left;
+}
+
+.club-popup-advised-edit {
+    margin: 0;
+    height: 1.5rem;
+    flex-grow: 0;
+}
+
 .club-popup-name-input {
-    width: 98%;
     font-size: 1.1rem;
+    margin-right: 1rem;
+    flex-grow: 1;
 }
 
 .club-popup-description-input {


### PR DESCRIPTION
### Description

There is now a button on the club edit, next to the name that allows you to toggle between advised/independent club.

### Fixes #219 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md)
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
