### PR TITLE
Page no longer scrolls when popup closes

### DIFF
--- a/client/src/components/Menu.js
+++ b/client/src/components/Menu.js
@@ -22,7 +22,9 @@ class Menu extends React.Component {
 
         if (this.props.location.pathname.includes('/search')) this.setState({ searchBar: null });
         else this.setState({ searchBar: <SearchBar className="menu-item"></SearchBar> });
-        if (this.props.location.search === '') window.scrollTo(0, 0);
+        if (this.props.location.search === '' && this.props.location.pathname !== prevProps.location.pathname) {
+            window.scrollTo(0, 0);
+        }
     }
 
     render() {


### PR DESCRIPTION
### Description

Page doesn't scroll to top when a popup is closed, but still does when a route is changed.

### Fixes #N/A

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md)
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request
