### PR TITLE
Added dayjs element to event after editing

### DIFF
--- a/client/src/components/home/event-popup.js
+++ b/client/src/components/home/event-popup.js
@@ -151,8 +151,11 @@ class EventPopup extends React.Component {
                 start,
                 end
             );
+            
+            addDayjsElement(eventObj);
             this.props.updateEvent(this.state.event.objId, eventObj);
             this.props.setPopupEdit(false);
+
             this.setState({ event: fullEvent });
             alert('Successfully edited!');
         } else alert('Editing event failed :(');


### PR DESCRIPTION
### Description

BUG FIX - event editing crashes because it expects there to be a dayjs element created for it. I fixed it by calling the create dayjs function after updating an event.

### Fixed N/A

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request