### PR TITLE
Added link parsing in descriptions

### DIFF
--- a/client/src/components/add-event/add.js
+++ b/client/src/components/add-event/add.js
@@ -235,7 +235,7 @@ class Add extends React.Component {
                         name="description"
                         className="add-description-input"
                         type="text"
-                        placeholder="Enter a description for your event"
+                        placeholder="Enter a description for your event (use http/https to hyperlink urls automatically)"
                         value={this.state.description}
                         onChange={this.handleInputChange}
                     ></textarea>

--- a/client/src/components/clubs/club-popup.js
+++ b/client/src/components/clubs/club-popup.js
@@ -23,7 +23,7 @@ import {
 } from '../../redux/actions';
 import { deleteClub, getClub, postClub } from '../../functions/api';
 import { Club, ClubInfo, Committee, Exec } from '../../functions/entries';
-import { compressUploadedImage, imgUrl, isActive } from '../../functions/util';
+import { compressUploadedImage, imgUrl, isActive, parseLinks } from '../../functions/util';
 
 import './club-popup.scss';
 
@@ -146,8 +146,7 @@ class ClubPopup extends React.Component {
                 clubObj.objId = res.id;
                 fullClub.objId = res.id;
                 this.props.addClub(clubObj);
-            }
-            else this.props.updateClub(this.state.club.objId, clubObj);
+            } else this.props.updateClub(this.state.club.objId, clubObj);
 
             this.props.setPopupEdit(false);
 
@@ -318,6 +317,8 @@ class ClubPopup extends React.Component {
             );
         }
 
+        const description = parseLinks('club-popup-description', this.state.club.description);
+
         return (
             <div className="club-popup">
                 <div className={isActive('club-popup-view', !this.props.edit)}>
@@ -326,7 +327,7 @@ class ClubPopup extends React.Component {
                         {this.state.club.advised ? 'Advised' : 'Independent'}
                     </p>
                     <p className="club-popup-name">{this.state.club.name}</p>
-                    <p className="club-popup-description">{this.state.club.description}</p>
+                    {description}
                     <div className="club-popup-links">
                         <p className="club-popup-link fb" onClick={() => window.open(this.state.club.website)}>
                             {this.state.club.website}

--- a/client/src/components/clubs/club-popup.scss
+++ b/client/src/components/clubs/club-popup.scss
@@ -51,6 +51,7 @@
     padding: 0.5rem 1.75rem;
     font-family: $alt-font;
     font-size: 0.5rem;
+    white-space: pre-line;
 }
 
 /*

--- a/client/src/components/home/event-popup.js
+++ b/client/src/components/home/event-popup.js
@@ -14,6 +14,7 @@ import {
     parseTimeZone,
     getTimezone,
     isPopupInvalid,
+    parseLinks,
 } from '../../functions/util';
 
 import './event-popup.scss';
@@ -252,6 +253,8 @@ class EventPopup extends React.Component {
             }
         }
 
+        const description = parseLinks('event-popup-description', this.state.event.description);
+
         return (
             <div className="event-popup">
                 <div className={'event-popup-display' + (!this.props.edit ? ' active' : ' inactive')}>
@@ -272,11 +275,11 @@ class EventPopup extends React.Component {
                                 onClick={this.toggleEditedBy}
                                 dangerouslySetInnerHTML={{ __html: editedByDisplay }}
                             ></p>
-                            <ActionButton className="event-popup-open-edit" onClick={this.openEdit}>Edit</ActionButton>
+                            <ActionButton className="event-popup-open-edit" onClick={this.openEdit}>
+                                Edit
+                            </ActionButton>
                         </div>
-                        <div className="event-popup-right event-popup-home-side">
-                            <p className="event-popup-description">{this.state.event.description}</p>
-                        </div>
+                        <div className="event-popup-right event-popup-home-side">{description}</div>
                     </div>
                 </div>
                 <div className={'event-popup-edit' + (this.props.edit ? ' active' : ' inactive')}>

--- a/client/src/components/resources/volunteering-popup.js
+++ b/client/src/components/resources/volunteering-popup.js
@@ -4,7 +4,7 @@ import ActionButton from '../shared/action-button';
 
 import { postVolunteering } from '../../functions/api';
 import { Volunteering } from '../../functions/entries';
-import { formatVolunteeringFilters, getOrFetchVolList } from '../../functions/util';
+import { formatVolunteeringFilters, getOrFetchVolList, parseLinks } from '../../functions/util';
 import { getPopupEdit, getPopupId, getPopupOpen, getPopupNew, getSavedVolunteeringList } from '../../redux/selectors';
 import {
     setPopupOpen,
@@ -162,6 +162,8 @@ class VolunteeringPopup extends React.Component {
             );
         }
 
+        const description = parseLinks('res-popup-description', this.state.vol.description);
+
         return (
             <div className="VolunteeringPopup">
                 <div className={'display' + (!this.props.edit ? ' active' : ' inactive')}>
@@ -172,7 +174,7 @@ class VolunteeringPopup extends React.Component {
                     )}
                     <p className="res-popup-name">{this.state.vol.name}</p>
                     <p className="res-popup-club">{this.state.vol.club}</p>
-                    <p className="res-popup-description">{this.state.vol.description}</p>
+                    {description}
                     {filters}
                     <ActionButton className="res-popup-edit" onClick={this.openEdit}>
                         Edit
@@ -213,7 +215,7 @@ class VolunteeringPopup extends React.Component {
                         name="description"
                         className="description-input"
                         type="text"
-                        placeholder="Enter a description for your event"
+                        placeholder="Enter a description for your volunteering (use http/https to hyperlink urls automatically)"
                         value={this.state.description}
                         onChange={this.handleInputChange}
                     ></textarea>

--- a/client/src/components/resources/volunteering-popup.scss
+++ b/client/src/components/resources/volunteering-popup.scss
@@ -31,6 +31,12 @@
     color: $text-light;
 }
 
+.res-popup-description {
+    font-size: 0.65rem;
+    font-family: $alt-font;
+    white-space: pre-line;
+}
+
 .VolunteeringPopup .action-button {
     margin-top: 0.5rem;
 }

--- a/client/src/functions/util.js
+++ b/client/src/functions/util.js
@@ -311,3 +311,37 @@ export function catchError(status, message = '') {
     }
     return false;
 }
+
+/**
+ * Takes in text and a classname, parses the links, and creates
+ * a paragraph element with the links in <a> tags
+ *
+ * @param {string} className Classname prop to add to outer paragraph element
+ * @param {string} text The text to parse and display
+ * @returns {object} A React jsx <p> component with links wrapped in <a> tags
+ */
+export function parseLinks(className, text) {
+    const re = /((?:http|https):\/\/.+?)(?:\.|\?|!)?(?:\s|$)/g;
+    var m;
+    var matches = [];
+    do {
+        m = re.exec(text);
+        if (m) matches.push(m);
+    } while (m);
+
+    var tempText = text;
+    var outText = [];
+    var prevIndex = 0;
+    matches.forEach((m) => {
+        outText.push(tempText.substring(prevIndex, tempText.indexOf(m[1])));
+        outText.push(
+            <a key={m[1]} href={m[1]} alt={m[1]}>
+                {m[1]}
+            </a>
+        );
+        tempText = tempText.substring(tempText.indexOf(m[1]) + m[1].length);
+    });
+    outText.push(tempText);
+
+    return <p className={className}>{outText}</p>;
+}


### PR DESCRIPTION
### Description

Links (https://blahblahblah.com) are now parsed using regex. This will detect any link that starts with http or https. 

### Fixes #234 

### Type of change

Delete options that do not apply:

- New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request