### PR TITLE
Clubs now show updated images

### DIFF
--- a/client/src/components/clubs/club-popup.js
+++ b/client/src/components/clubs/club-popup.js
@@ -143,15 +143,21 @@ class ClubPopup extends React.Component {
             );
 
             if (this.props.new) {
-                clubObj.objId = res.id;
-                fullClub.objId = res.id;
+                clubObj.objId = res.data.id;
+                fullClub.objId = res.data.id;
                 this.props.addClub(clubObj);
             } else this.props.updateClub(this.state.club.objId, clubObj);
 
-            this.props.setPopupEdit(false);
+            // If images were changed, use the blob urls for the pictures
+            if (this.state.compressed !== null) {
+                fullClub.coverImg = this.state.coverImg;
+            }
 
-            if (this.props.new) this.props.setPopupOpen(false);
-            else this.resetState(fullClub);
+            if (this.props.new) this.props.resetPopupState();
+            else {
+                this.props.setPopupEdit(false);
+                this.resetState(fullClub);
+            }
 
             alert('Successfully added!');
         } else alert('Adding club failed :(');
@@ -225,7 +231,6 @@ class ClubPopup extends React.Component {
     addExec = () => {
         var execs = this.state.execs;
         var execBlobs = this.state.execBlobs;
-        // TODO: Add default constructor for exec & committee (prob convert to classes in entries.js)
         execs.push(new Exec());
         execBlobs.push(null);
         this.setState({ execs, execBlobs });


### PR DESCRIPTION
### Description

After updating a club, the popup will update to reflect the changed images.

### Fixes #241 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request