### PR TITLE
FIX: now backend gets correct header for user IP

### DIFF
--- a/server/src/util.js
+++ b/server/src/util.js
@@ -75,7 +75,7 @@ async function parseForm(req, res, callback) {
  * @param {import('express').Request} req Express request object
  */
 function getIp(req) {
-    return req.ip || req.connection.remoteAddress;
+    return req.headers['X-Real-IP'] || req.connection.remoteAddress;
 }
 
 module.exports = { sendError, logRequest, parseForm, getIp };


### PR DESCRIPTION
### Description

`req.ip` returns the wrong IP address. I'm using `req.headers['X-Real-IP']`, which is returned by NGINX.

### Fixes incorrect IP added to edited by

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [ ] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [ ] I have **fully** commented my code, especially in hard-to-understand areas
- [ ] I have made changes to the documentation OR created an issue to update documentation
- [ ] All existing functionality (if a non-breaking change) still works as it should
- [ ] I have assigned at least one person to review my pull request