### PR TITLE
Headers aren't case sensitive

### DIFF
--- a/server/src/util.js
+++ b/server/src/util.js
@@ -75,7 +75,7 @@ async function parseForm(req, res, callback) {
  * @param {import('express').Request} req Express request object
  */
 function getIp(req) {
-    return req.headers['X-Real-IP'] || req.connection.remoteAddress;
+    return req.headers['x-real-ip'] || req.connection.remoteAddress;
 }
 
 module.exports = { sendError, logRequest, parseForm, getIp };


### PR DESCRIPTION
### Description

The header automatically is converted to lowercase, so I needed to get `x-real-ip` instead of `X-Real-IP` -_-

### Fixes N/A

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [ ] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [ ] I have **fully** commented my code, especially in hard-to-understand areas
- [ ] I have made changes to the documentation OR created an issue to update documentation
- [ ] All existing functionality (if a non-breaking change) still works as it should
- [ ] I have assigned at least one person to review my pull request