### PR TITLE
Popup cleanup

### DIFF
--- a/client/src/components/clubs/club-popup.scss
+++ b/client/src/components/clubs/club-popup.scss
@@ -15,6 +15,11 @@
     text-align: center;
 }
 
+// TODO: This component is still weird
+.club-popup-loading {
+    padding: 1rem;
+}
+
 /*
  * ######################
  * ##### POPUP INFO #####

--- a/client/src/components/clubs/clubs.js
+++ b/client/src/components/clubs/clubs.js
@@ -6,7 +6,7 @@ import ClubPopup from './club-popup';
 import Popup from '../shared/popup';
 
 import { getSavedClubList } from '../../redux/selectors';
-import { setClubList, setPopupOpen, setPopupId, setPopupNew, setPopupEdit, setPopupType } from '../../redux/actions';
+import { openPopup } from '../../redux/actions';
 
 import './clubs.scss';
 import Loading from '../shared/loading';
@@ -14,15 +14,7 @@ import Loading from '../shared/loading';
 class Clubs extends React.Component {
     activatePopup = (id) => {
         this.props.history.push(`/clubs?id=${id}`);
-        this.props.setPopupId(id);
-        this.props.setPopupType('club');
-        this.props.setPopupOpen(true);
-    };
-
-    addClub = () => {
-        this.props.setPopupNew(true);
-        this.props.setPopupEdit(true);
-        this.activatePopup('new');
+        this.props.openPopup(id, 'clubs');
     };
 
     createCards = () => {
@@ -52,6 +44,6 @@ const mapStateToProps = (state) => {
         clubList: getSavedClubList(state),
     };
 };
-const mapDispatchToProps = { setClubList, setPopupOpen, setPopupId, setPopupNew, setPopupEdit, setPopupType };
+const mapDispatchToProps = { openPopup };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Clubs);

--- a/client/src/components/home/event-popup.js
+++ b/client/src/components/home/event-popup.js
@@ -182,14 +182,6 @@ class EventPopup extends React.Component {
             )
         );
 
-        // Create edited by display (if set to true or else just display added by)
-        var editedByDisplay = `Added by: ${this.state.event.editedBy[0]}`;
-        if (this.state.showEditedBy) {
-            for (var i = 1; i < this.state.event.editedBy.length; i++) {
-                editedByDisplay += `<br />Edited by: ${this.state.event.editedBy[i]}`;
-            }
-        }
-
         const description = parseLinks('event-popup-description', this.state.event.description);
 
         return (
@@ -206,11 +198,6 @@ class EventPopup extends React.Component {
                         <p className="event-popup-date">{getFormattedDate(this.state.event)}</p>
                         <p className="event-popup-time">{getFormattedTime(this.state.event)}</p>
                         {linkData}
-                        <p
-                            className="event-popup-edited-by"
-                            onClick={this.toggleEditedBy}
-                            dangerouslySetInnerHTML={{ __html: editedByDisplay }}
-                        ></p>
                         <ActionButton className="event-popup-open-edit" onClick={this.openEdit}>
                             Edit
                         </ActionButton>

--- a/client/src/components/home/event-popup.scss
+++ b/client/src/components/home/event-popup.scss
@@ -99,6 +99,7 @@
 }
 
 .event-popup-description {
+    padding-right: 0.5rem;
     font-size: 0.55rem;
     white-space: pre-line;
 }

--- a/client/src/components/home/event-popup.scss
+++ b/client/src/components/home/event-popup.scss
@@ -93,13 +93,6 @@
     color: $primary;
 }
 
-.event-popup-edited-by {
-    margin-top: 3rem;
-    font-size: 0.45rem;
-    color: $text-lighter;
-    cursor: pointer;
-}
-
 .event-popup-open-edit {
     font-size: 0.65rem;
     padding: 0.1rem 0.25rem;

--- a/client/src/components/home/home.js
+++ b/client/src/components/home/home.js
@@ -1,44 +1,24 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import dayjs from 'dayjs';
-import arraySupport from 'dayjs/plugin/arraySupport';
 
 import DateSection from './date-section';
 import ScheduleEvent from './schedule-event';
-import CalendarDay from './calendar-day';
 import Popup from '../shared/popup';
 import EventPopup from './event-popup';
-
-import { setEventList, setPopupOpen, setPopupId } from '../../redux/actions';
-import { getSavedEventList } from '../../redux/selectors';
-import { getEventList } from '../../functions/api';
-import {
-    createDateHeader,
-    insertDateDividers,
-    addDayjsElement,
-    getMonthAndYear,
-    generateCalendarDays,
-    pad,
-    isActive,
-} from '../../functions/util';
-
-import data from '../../files/data.json';
-import './home.scss';
 import Calendar from './calendar';
 import Loading from '../shared/loading';
+
+import { createDateHeader, insertDateDividers, getMonthAndYear, isActive } from '../../functions/util';
+import { openPopup } from '../../redux/actions';
+import { getSavedEventList } from '../../redux/selectors';
+
+import './home.scss';
 
 class Home extends React.Component {
     constructor(props) {
         super(props);
-
-        // Use DayJS plugin to parse arrays of dates
-        dayjs.extend(arraySupport);
-
-        // Set default state
-        this.state = {
-            scheduleView: true,
-            monthOffset: 0,
-        };
+        this.state = { scheduleView: true, monthOffset: 0 };
     }
 
     switchView = () => {
@@ -55,8 +35,7 @@ class Home extends React.Component {
 
     activatePopup = (id) => {
         this.props.history.push(`/events?id=${id}`);
-        this.props.setPopupId(id);
-        this.props.setPopupOpen(true);
+        this.props.openPopup(id, 'events');
     };
 
     createEventComponents = () => {
@@ -145,9 +124,7 @@ class Home extends React.Component {
                         {'<'}
                     </button>
                     <div className="month-year">{getMonthAndYear(this.state.monthOffset)}</div>
-                    <div
-                        className={isActive('dummy-change-month month-forward', this.state.scheduleView)}
-                    ></div>
+                    <div className={isActive('dummy-change-month month-forward', this.state.scheduleView)}></div>
                     <button
                         className={isActive('change-month month-forward', !this.state.scheduleView)}
                         onClick={this.changeMonthOffset.bind(this, false)}
@@ -175,6 +152,7 @@ const mapStateToProps = (state) => {
         eventList: getSavedEventList(state),
     };
 };
-const mapDispatchToProps = { setEventList, setPopupOpen, setPopupId };
+
+const mapDispatchToProps = { openPopup };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Home);

--- a/client/src/components/shared/popup.js
+++ b/client/src/components/shared/popup.js
@@ -2,22 +2,14 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { isActive } from '../../functions/util';
-import { getPopupEdit, getPopupId, getPopupOpen, getPopupNew, getPopupDeleted, getPopupType } from '../../redux/selectors';
-import {
-    setPopupOpen,
-    setPopupId,
-    setPopupEdit,
-    resetPopupState,
-    setPopupNew,
-    deleteSavedClub,
-} from '../../redux/actions';
+import { getPopupOpen } from '../../redux/selectors';
+import { resetPopupState } from '../../redux/actions';
 
 import './popup.scss';
 
 class Popup extends React.Component {
     close = () => {
-        if (window.location.pathname == '/event') this.props.history.push('/');
-        else this.props.history.push(`${window.location.pathname}`);
+        this.props.history.push(`${window.location.pathname}`);
         this.props.resetPopupState();
     };
 
@@ -27,16 +19,6 @@ class Popup extends React.Component {
                 this.close();
             }
         });
-    }
-
-    componentDidUpdate() {
-        if (this.props.deleted) {
-            if (this.props.type === 'club') {
-                this.props.deleteSavedClub(this.props.id);
-                this.props.history.push('/clubs');
-            }
-            this.props.resetPopupState();
-        }
     }
 
     render() {
@@ -52,13 +34,8 @@ class Popup extends React.Component {
 const mapStateToProps = (state) => {
     return {
         open: getPopupOpen(state),
-        id: getPopupId(state),
-        edit: getPopupEdit(state),
-        new: getPopupNew(state),
-        deleted: getPopupDeleted(state),
-        type: getPopupType(state),
     };
 };
-const mapDispatchToProps = { setPopupOpen, setPopupId, setPopupEdit, resetPopupState, setPopupNew, deleteSavedClub };
+const mapDispatchToProps = { resetPopupState };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Popup);

--- a/client/src/components/shared/popup.js
+++ b/client/src/components/shared/popup.js
@@ -26,6 +26,9 @@ class Popup extends React.Component {
             <div className={`popup ${isActive('', this.props.open)} ${this.props.noscroll ? 'noscroll' : ''}`}>
                 <div className="popup-close-bkgd" onClick={this.close}></div>
                 <div className="popup-content">{this.props.children}</div>
+                <button className="popup-close-button" onClick={this.close}>
+                    x
+                </button>
             </div>
         );
     }

--- a/client/src/components/shared/popup.scss
+++ b/client/src/components/shared/popup.scss
@@ -43,6 +43,24 @@
     overflow-y: hidden !important;
 }
 
+.popup-close-button {
+    display: none;
+    position: fixed;
+    right: 0.75rem;
+    top: 0.5rem;
+
+    width: 1rem;
+    height: 1rem;
+    padding: 0;
+    border-radius: 1rem;
+    border: 0.05rem solid $text-primary;
+    
+    text-align: center;
+    color: $text-primary;
+    background-color: rgba($background, 0.65);
+    cursor: pointer;
+}
+
 /*
  * #########################
  * ##### MEDIA QUERIES #####
@@ -68,5 +86,9 @@
         max-height: 100vh;
         margin: 0;
         box-shadow: none;
+    }
+
+    .popup-close-button {
+        display: block;
     }
 }

--- a/client/src/components/shared/popup.scss
+++ b/client/src/components/shared/popup.scss
@@ -20,10 +20,6 @@
     backdrop-filter: blur(0.1rem);
 }
 
-.popup.active {
-    display: block;
-}
-
 .popup-close-bkgd {
     position: absolute;
     width: 100%;

--- a/client/src/components/volunteering/volunteering-popup.js
+++ b/client/src/components/volunteering/volunteering-popup.js
@@ -1,16 +1,13 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import ActionButton from '../shared/action-button';
+import Loading from '../shared/loading';
 
 import { formatVolunteeringFilters, parseLinks } from '../../functions/util';
-import { getPopupId, getPopupOpen, getSavedVolunteeringList } from '../../redux/selectors';
-import {
-    setPopupOpen,
-    setPopupId,
-} from '../../redux/actions';
+import { getPopupId, getPopupOpen, getPopupType, getSavedVolunteeringList } from '../../redux/selectors';
+import { openPopup } from '../../redux/actions';
 
 import './volunteering-popup.scss';
-import Loading from '../shared/loading';
 
 class VolunteeringPopup extends React.Component {
     constructor(props) {
@@ -24,16 +21,18 @@ class VolunteeringPopup extends React.Component {
 
     getVol = async () => {
         const vol = this.props.volList.find((v) => v._id === this.props.id);
-        this.setState({vol});
+        this.setState({ vol });
     };
 
     componentDidMount() {
-        if (this.props.volList !== null && this.props.id !== '') this.getVol();
+        if (this.props.volList !== null && this.props.id !== '' && this.props.type === 'volunteering') this.getVol();
     }
 
     componentDidUpdate(prevProps) {
-        // If id not valid, ignore updates
-        if (this.props.id === '') return;
+        // TODO: Simplify this if possible because it's really confusing rn
+
+        // If id or type not valid, ignore updates
+        if (this.props.id === '' || this.props.type !== 'volunteering') return;
 
         // On volunteering list or id change, update the current volunteering
         if (
@@ -79,11 +78,12 @@ class VolunteeringPopup extends React.Component {
 
 const mapStateToProps = (state) => {
     return {
-        popupOpen: getPopupOpen(state),
-        id: getPopupId(state),
         volList: getSavedVolunteeringList(state),
+        type: getPopupType(state),
+        open: getPopupOpen(state),
+        id: getPopupId(state),
     };
 };
-const mapDispatchToProps = { setPopupOpen, setPopupId };
+const mapDispatchToProps = { openPopup };
 
 export default connect(mapStateToProps, mapDispatchToProps)(VolunteeringPopup);

--- a/client/src/components/volunteering/volunteering.js
+++ b/client/src/components/volunteering/volunteering.js
@@ -8,7 +8,7 @@ import VolunteeringPopup from './volunteering-popup';
 import ActionButton from '../shared/action-button';
 
 import { getSavedVolunteeringList } from '../../redux/selectors';
-import { setVolunteeringList, setPopupOpen, setPopupId, setPopupNew, setPopupEdit } from '../../redux/actions';
+import { setVolunteeringList, openPopup } from '../../redux/actions';
 
 import './volunteering.scss';
 import Loading from '../shared/loading';
@@ -21,14 +21,7 @@ class Volunteering extends React.Component {
 
     activatePopup = (id) => {
         this.props.history.push(`/volunteering?id=${id}`);
-        this.props.setPopupId(id);
-        this.props.setPopupOpen(true);
-    };
-
-    addVolunteering = () => {
-        this.props.setPopupNew(true);
-        this.props.setPopupEdit(true);
-        this.activatePopup('new');
+        this.props.openPopup(id, 'volunteering');
     };
 
     updateFilter = (filter) => {
@@ -112,6 +105,6 @@ const mapStateToProps = (state) => {
         volunteeringList: getSavedVolunteeringList(state),
     };
 };
-const mapDispatchToProps = { setVolunteeringList, setPopupOpen, setPopupId, setPopupNew, setPopupEdit };
+const mapDispatchToProps = { setVolunteeringList, openPopup };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Volunteering);

--- a/client/src/components/volunteering/volunteering.js
+++ b/client/src/components/volunteering/volunteering.js
@@ -1,17 +1,15 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import LinkBox from '../shared/link-box';
 import Popup from '../shared/popup';
 import VolunteeringCard from './volunteering-card';
 import VolunteeringPopup from './volunteering-popup';
-import ActionButton from '../shared/action-button';
+import Loading from '../shared/loading';
 
 import { getSavedVolunteeringList } from '../../redux/selectors';
 import { setVolunteeringList, openPopup } from '../../redux/actions';
 
 import './volunteering.scss';
-import Loading from '../shared/loading';
 
 class Volunteering extends React.Component {
     constructor(props) {

--- a/client/src/components/volunteering/volunteering.scss
+++ b/client/src/components/volunteering/volunteering.scss
@@ -17,17 +17,18 @@
 }
 
 .vol-filter {
-    background-color: $background;
-    border: 0.1rem solid $background-tint;
-    border-radius: 1rem;
     width: 5rem;
-    // TODO: Fix slightly off button ratios
     padding: 0.2rem 0.1rem;
     margin-right: 0.5rem;
     margin-bottom: 0.5rem;
+    border: 0.1rem solid $background-tint;
+    border-radius: 1rem;
+
     font-family: $title-font;
     font-size: 0.45rem;
     font-weight: 400;
+
+    background-color: $background;
     transition: 0.2s;
 }
 
@@ -96,8 +97,12 @@
 }
 
 @include media-small-desktop-down {
-    .resources-link-container {
-        margin: 0 1rem 1rem;
+    .vol-filter {
+        font-size: 0.5rem !important;
+        width: 5rem !important;
+    }
+    .volunteering-filters {
+        margin: 1rem 0;
     }
     .volunteering-section {
         margin: 0 0 1rem;
@@ -106,6 +111,6 @@
 
 @include media-tablet-down {
     .volunteering-filters {
-        margin: 1rem 10vw 0;
+        margin: 1rem 10vw 0 !important;
     }
 }

--- a/client/src/functions/routing-requests.js
+++ b/client/src/functions/routing-requests.js
@@ -13,6 +13,7 @@ import {
     setClubList,
     setVolunteeringList,
     setMobileDropdown,
+    openPopup,
 } from '../redux/actions';
 
 class RoutingRequests extends React.Component {
@@ -63,23 +64,10 @@ class RoutingRequests extends React.Component {
         }
     };
 
-    activatePopup = (id) => {
-        // Detect if new and set relevant flags
-        if (id === 'new') {
-            this.props.setPopupNew(true);
-            this.props.setPopupEdit(true);
-        }
-
-        // Set the ID and open the popup
-        this.props.setPopupId(id);
-        this.props.setPopupOpen(true);
-        console.log(id);
-    };
-
     componentDidMount() {
         // Activate popup
         const id = getParams('id');
-        if (id !== undefined && id !== null) this.activatePopup(id);
+        if (id !== undefined && id !== null) this.props.openPopup(id, window.location.pathname.substring(1));
 
         // Fetch data
         this.fetchData();
@@ -129,8 +117,7 @@ const mapStateToProps = (state) => {
     };
 };
 const mapDispatchToProps = {
-    setPopupOpen,
-    setPopupId,
+    openPopup,
     resetPopupState,
     setEventList,
     setVolunteeringList,

--- a/client/src/redux/actionTypes.js
+++ b/client/src/redux/actionTypes.js
@@ -19,4 +19,5 @@ export const SET_NEW = '[Popup] Set Is New';
 export const SET_ID = '[Popup] Set ID';
 export const SET_DELETED = '[Popup] Set Is Deleted';
 export const SET_TYPE = '[Popup] Set Type';
-export const SET_MOBILE_DROPDOWN = '[Popup] Set Mobile Dropdown Open'
+export const SET_MOBILE_DROPDOWN = '[Popup] Set Mobile Dropdown Open';
+export const OPEN_POPUP = '[Popup] Open Popup on Click';

--- a/client/src/redux/actions.js
+++ b/client/src/redux/actions.js
@@ -18,6 +18,7 @@ import {
     SET_TYPE,
     ADD_EVENT,
     SET_MOBILE_DROPDOWN,
+    OPEN_POPUP,
 } from './actionTypes';
 
 export const resetDataState = () => ({
@@ -111,4 +112,9 @@ export const addEvent = (event) => ({
 export const setMobileDropdown = (open) => ({
     type: SET_MOBILE_DROPDOWN,
     payload: { open },
+});
+
+export const openPopup = (id, type) => ({
+    type: OPEN_POPUP,
+    payload: { id, type },
 });

--- a/client/src/redux/reducers/popup.js
+++ b/client/src/redux/reducers/popup.js
@@ -7,6 +7,7 @@ import {
     SET_DELETED,
     SET_TYPE,
     SET_MOBILE_DROPDOWN,
+    OPEN_POPUP,
 } from '../actionTypes';
 
 const initialState = {
@@ -15,7 +16,7 @@ const initialState = {
     new: false,
     id: '',
     deleted: false,
-    type: '',
+    type: '', // events | volunteering | clubs
     mobileDropdown: false,
 };
 
@@ -71,6 +72,15 @@ export default function popup(state = initialState, action) {
             return {
                 ...state,
                 mobileDropdown: open,
+            };
+        }
+        case OPEN_POPUP: {
+            const { id, type } = action.payload;
+            return {
+                ...state,
+                id,
+                type,
+                open: true,
             };
         }
         default:


### PR DESCRIPTION
### Description

- Clean up useless popup code
- Use `type` redux store field to save the type of popup (`events`, `volunteering`, or `clubs`) so that a strange bug would not happen when switching from a popup to the home page
- Added a close button for mobile popups
- Adjusted the size of volunteering filters on mobile

### Fixes N/A

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request