### PR TITLE
redirect instead of route on edit submit

### DIFF
--- a/client/src/components/edit/edit-clubs.js
+++ b/client/src/components/edit/edit-clubs.js
@@ -151,7 +151,7 @@ class EditClubs extends React.Component {
         // Get response and send to user
         if (res.status === 200) {
             alert(`Successfully ${this.state.new ? 'added' : 'edited'} club!`);
-            this.props.parentHistory.push(`/clubs${window.location.search}`);
+            window.location.href = `${window.location.origin}/clubs${window.location.search}`;
         } else alert(`${this.state.new ? 'Adding' : 'Editing'} club failed :(`);
     };
 

--- a/client/src/components/edit/edit-events.js
+++ b/client/src/components/edit/edit-events.js
@@ -6,7 +6,6 @@ import { Event } from '../../functions/entries';
 import { parseTimeZone, getTimezone, getParams, millisToDateAndTime } from '../../functions/util';
 import './edit-events.scss';
 import Loading from '../shared/loading';
-import { withRouter } from 'react-router';
 import SubmitGroup from '../shared/submit-group';
 
 class EditEvents extends React.Component {
@@ -72,7 +71,7 @@ class EditEvents extends React.Component {
         // Get response and send to user
         if (res.status === 200) {
             alert(`Successfully ${this.state.new ? 'added' : 'edited'} event!`);
-            this.props.parentHistory.push(`/events${window.location.search}`);
+            window.location.href = `${window.location.origin}/events${window.location.search}`;
         } else alert(`${this.state.new ? 'Adding' : 'Editing'} event failed :(`);
     };
 
@@ -237,4 +236,4 @@ class EditEvents extends React.Component {
     }
 }
 
-export default withRouter(EditEvents);
+export default EditEvents;

--- a/client/src/components/edit/edit-volunteering.js
+++ b/client/src/components/edit/edit-volunteering.js
@@ -68,7 +68,7 @@ class EditVolunteering extends React.Component {
         // Get response and send to user
         if (res.status === 200) {
             alert(`Successfully ${this.state.new ? 'added' : 'edited'} volunteering!`);
-            this.props.parentHistory.push(`/volunteering${window.location.search}`);
+            window.location.href = `${window.location.origin}/volunteering${window.location.search}`;
         } else alert(`${this.state.new ? 'Adding' : 'Editing'} volunteering failed :(`);
     };
 

--- a/client/src/components/edit/edit.js
+++ b/client/src/components/edit/edit.js
@@ -14,15 +14,9 @@ class Edit extends React.Component {
                     <EditLogin />
                     <EditHistory />
                     <Switch>
-                        <Route path="/edit/events">
-                            <EditEvents parentHistory={this.props.history}></EditEvents>
-                        </Route>
-                        <Route path="/edit/clubs">
-                            <EditClubs parentHistory={this.props.history}></EditClubs>
-                        </Route>
-                        <Route path="/edit/volunteering">
-                            <EditVolunteering parentHistory={this.props.history}></EditVolunteering>
-                        </Route>
+                        <Route path="/edit/events" component={EditEvents} />
+                        <Route path="/edit/clubs" component={EditClubs} />
+                        <Route path="/edit/volunteering" component={EditVolunteering} />
                         <Route>
                             <div className="edit-no-route center-text">ERROR: Invalid editing URL!</div>
                         </Route>


### PR DESCRIPTION
### Description

Whenever a resource edit was submitted, the redirect would not load the resources properly. To fix this, we simply redirect the user instead of using react routes.

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request