### PR TITLE
HOTFIX: popups now work through search

### DIFF
--- a/client/src/components/menu/search.js
+++ b/client/src/components/menu/search.js
@@ -7,7 +7,7 @@ import SearchBar from './search-bar';
 import SearchResult from './search-result';
 
 import { getEventList } from '../../functions/api';
-import { setEventList, setPopupId, setPopupOpen } from '../../redux/actions';
+import { setEventList, openPopup } from '../../redux/actions';
 import { getSavedEventList } from '../../redux/selectors';
 
 import './search.scss';
@@ -20,8 +20,7 @@ class Search extends React.Component {
 
     activatePopup = (id) => {
         this.props.history.push(`/events?id=${id}`);
-        this.props.setPopupId(id);
-        this.props.setPopupOpen(true);
+        this.props.openPopup(id, 'events');
     };
 
     componentDidMount() {
@@ -79,6 +78,6 @@ const mapStateToProps = (state) => {
         eventList: getSavedEventList(state),
     };
 };
-const mapDispatchToProps = { setEventList, setPopupId, setPopupOpen };
+const mapDispatchToProps = { setEventList, openPopup };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Search);


### PR DESCRIPTION
### Description

Clicking on events in search now properly opens the popup.

### Fixes #[Issue]

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request