### PR TITLE
Messages + cosmetic changes

### DIFF
--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -1,9 +1,11 @@
 @import './custom.scss';
 
+// Min height is so scrollbar always shows
+// I can't do 'overflow: scroll' beacuse it would break the sticky containers TT
 html,
 body,
 #root {
-    min-height: 100%;
+    min-height: 101vh;
     margin: 0;
 
     font-size: 36px;

--- a/client/src/components/clubs/club-popup.js
+++ b/client/src/components/clubs/club-popup.js
@@ -99,9 +99,19 @@ class ClubPopup extends React.Component {
                         </div>
                     </div>
                     {this.state.execTab ? (
-                        <div className="club-popup-execs">{execList}</div>
+                        <div className="club-popup-execs">
+                            <div className={isActive('club-popup-tab-empty', execList.length === 0)}>No execs ;-;</div>
+                            {execList}
+                        </div>
                     ) : (
-                        <div className="club-popup-committees">{committeeList}</div>
+                        <div className="club-popup-committees">
+                            <div className={isActive('club-popup-tab-empty', committeeList.length === 0)}>
+                                No committees :(
+                            </div>
+                            <div className={isActive('club-popup-committees-list', committeeList.length !== 0)}>
+                                {committeeList}
+                            </div>
+                        </div>
                     )}
                     <ActionButton className="club-popup-edit-button" onClick={this.openEdit}>
                         Edit

--- a/client/src/components/clubs/club-popup.scss
+++ b/client/src/components/clubs/club-popup.scss
@@ -119,14 +119,21 @@
     color: $primary;
 }
 
-.club-popup-committees {
+.club-popup-committees-list {
     grid-template-columns: repeat(auto-fill, 10rem);
     gap: 1rem;
     justify-content: center;
 
-    display: grid;
+    display: grid !important;
     margin: auto;
     margin-bottom: 1rem;
+}
+
+.club-popup-tab-empty {
+    margin-bottom: 0.5rem;
+    font-family: $title-font;
+    text-align: center;
+    color: $text-light;
 }
 
 .club-popup-edit-button {

--- a/client/src/components/edit/edit-clubs.scss
+++ b/client/src/components/edit/edit-clubs.scss
@@ -112,6 +112,7 @@
 }
 
 .edit-clubs-add-container {
+    margin-bottom: 0.5rem;
     text-align: center;
 }
 

--- a/client/src/components/home/calendar-day.js
+++ b/client/src/components/home/calendar-day.js
@@ -29,9 +29,11 @@ class CalendarDay extends React.Component {
     }
 
     render() {
+        const sideMonth = this.props.sideMonth ? 'side-month' : '';
+        const currentDay = this.props.currentDay ? 'current-day' : '';
         return (
-            <div className={'calendar-day' + (this.props.sideMonth ? ' side-month' : '')}>
-                <div className={'calendar-date' + (this.props.currentDay ? ' current-day' : '')}>{this.props.day}</div>
+            <div className={`calendar-day ${sideMonth} ${currentDay}`}>
+                <div className={`calendar-date ${currentDay}`}>{this.props.day}</div>
                 <div className="calendar-events">{this.state.events}</div>
             </div>
         );

--- a/client/src/components/home/calendar-day.scss
+++ b/client/src/components/home/calendar-day.scss
@@ -15,6 +15,10 @@
     border-style: solid;
 }
 
+.calendar-day.current-day {
+    background-color: rgba($primary, $alpha: 0.1);
+}
+
 .side-month {
     background-color: $background-tint;
 }
@@ -34,6 +38,6 @@
     flex-direction: column;
 }
 
-.current-day {
+.calendar-date.current-day {
     color: $primary;
 }

--- a/client/src/components/home/calendar.scss
+++ b/client/src/components/home/calendar.scss
@@ -62,3 +62,19 @@ $rh: 5rem;
     font-family: $title-font;
     font-weight: 300;
 }
+
+/*
+ * #########################
+ * ##### MEDIA QUERIES #####
+ * #########################
+ */
+
+@include media-small-desktop-down {
+    .calendar-header {
+        margin: 1rem 0.5rem 0;
+    }
+
+    .calendar-days {
+        margin: 0 0.5rem 0.5rem;
+    }
+}

--- a/client/src/components/home/date-section.scss
+++ b/client/src/components/home/date-section.scss
@@ -8,7 +8,7 @@
     padding: 0.5rem 0;
     font-size: 0.7rem;
     position: sticky;
-    top: 4.5rem;
+    top: 5rem;
     background-color: $background;
     font-family: $title-font;
 }

--- a/client/src/components/home/home.js
+++ b/client/src/components/home/home.js
@@ -15,6 +15,7 @@ import { openPopup } from '../../redux/actions';
 import { getSavedEventList } from '../../redux/selectors';
 
 import './home.scss';
+import ActionButton from '../shared/action-button';
 
 class Home extends React.Component {
     constructor(props) {
@@ -107,37 +108,38 @@ class Home extends React.Component {
         const eventComponents = this.createEventComponents();
 
         return (
-            <div className="Home">
+            <div className="home">
                 <Popup history={this.props.history}>
                     <EventPopup></EventPopup>
                 </Popup>
                 <AddButton type="Event"></AddButton>
                 <div className="home-top">
-                    <div className={isActive('dummy', this.state.scheduleView)}></div>
-                    <button className={isActive('today', !this.state.scheduleView)} onClick={this.resetMonthOffset}>
+                    <ActionButton className={isActive('home-top-item today', !this.state.scheduleView)} onClick={this.resetMonthOffset}>
                         Today
-                    </button>
-                    <div className={isActive('dummy-today', !this.state.scheduleView)}></div>
-                    <div className={isActive('dummy-change-month month-back', this.state.scheduleView)}></div>
-                    <button
-                        className={isActive('change-month month-back', !this.state.scheduleView)}
+                    </ActionButton>
+                    <ActionButton
+                        className={isActive('home-top-item month-change backward', !this.state.scheduleView)}
                         onClick={this.changeMonthOffset.bind(this, true)}
                     >
                         {'<'}
-                    </button>
-                    <div className="month-year">{getMonthAndYear(this.state.monthOffset)}</div>
-                    <div className={isActive('dummy-change-month month-forward', this.state.scheduleView)}></div>
-                    <button
-                        className={isActive('change-month month-forward', !this.state.scheduleView)}
+                    </ActionButton>
+                    <h1 className="home-top-item month-year">{getMonthAndYear(this.state.monthOffset)}</h1>
+                    <ActionButton
+                        className={isActive('home-top-item month-change forward', !this.state.scheduleView)}
                         onClick={this.changeMonthOffset.bind(this, false)}
                     >
                         {'>'}
-                    </button>
-                    <button className="view-switch" onClick={this.switchView}>
-                        {`Switch to ${this.state.scheduleView ? 'Calendar' : 'Schedule'} View`}
-                    </button>
+                    </ActionButton>
+                    <ActionButton className="home-top-item view-switch" onClick={this.switchView}>
+                        {`Show ${this.state.scheduleView ? 'Calendar' : 'Schedule'}`}
+                    </ActionButton>
                 </div>
-                <div className={isActive('schedule-view', this.state.scheduleView)}>{eventComponents}</div>
+                <div className={isActive('home-schedule-view', this.state.scheduleView)}>
+                    <div className={isActive('home-schedule-view-empty', eventComponents.length === 0)}>
+                        No upcoming events...
+                    </div>
+                    {eventComponents}
+                </div>
                 <Calendar
                     className={isActive('home-calendar', !this.state.scheduleView)}
                     eventList={this.props.eventList}

--- a/client/src/components/home/home.js
+++ b/client/src/components/home/home.js
@@ -114,7 +114,10 @@ class Home extends React.Component {
                 </Popup>
                 <AddButton type="Event"></AddButton>
                 <div className="home-top">
-                    <ActionButton className={isActive('home-top-item today', !this.state.scheduleView)} onClick={this.resetMonthOffset}>
+                    <ActionButton
+                        className={isActive('home-top-item today', !this.state.scheduleView)}
+                        onClick={this.resetMonthOffset}
+                    >
                         Today
                     </ActionButton>
                     <ActionButton
@@ -136,7 +139,8 @@ class Home extends React.Component {
                 </div>
                 <div className={isActive('home-schedule-view', this.state.scheduleView)}>
                     <div className={isActive('home-schedule-view-empty', eventComponents.length === 0)}>
-                        No upcoming events...
+                        No upcoming events... Well, you can
+                        <a href={`${window.origin}/edit/events`}> add one</a>!
                     </div>
                     {eventComponents}
                 </div>

--- a/client/src/components/home/home.scss
+++ b/client/src/components/home/home.scss
@@ -1,116 +1,104 @@
+/**
+ * The home component is the homepage of our site! By default, this will display a
+ * list of upcoming events, in order by starting date/time. There are many features of this
+ * simple page:
+ * 
+ * 1) Each date section is a sticky container, meaning that if there are enough events,
+ *    the date section will stay at the top when scrolled above the top of the page.
+ * 2) The button at the top will switch a calendar view of the events, implemented
+ *    in the Calendar component.
+ */
+
 @import '../../custom.scss';
 
-.schedule-view {
-    margin: 2rem 14vw 0 14vw;
-    padding-bottom: 0.5rem;
-}
-
-.home-calendar {
-    margin-top: 2.5rem;
-}
+/* 
+ * ####################
+ * ##### HOME TOP #####
+ * ####################
+ */
 
 .home-top {
     position: fixed;
     padding-top: 0.5rem;
     top: 2.5rem;
-    height: 1.5rem;
+    height: 2rem;
     width: 100%;
 
-    display: flex;
+    display: grid;
+    grid-template-columns: 15% 10% 15% 2.5% 20% 2.5% 5% 15% 15%;
     align-items: center;
-    justify-content: center;
-    
-    font-family: $title-font;    
+
+    font-family: $title-font;
     background-color: $background;
     z-index: 1;
 }
 
-.month-year {
-    text-align: center;
-    width: 6.5rem;
-    padding: 0 0.2rem;
-}
-
-.dummy-change-month {
-    display: none;
-    width: 1.3rem;
-}
-
-.today {
-    display: none;
-    font-family: $title-font;
-    text-align: center;
-    background-color: $background;
-    width: 2.5rem;
+.home-top button {
+    padding: 0.1rem 0;
     border: 0.1rem solid $text-primary;
-    padding: 0.1rem 0.25rem;
     font-size: 0.75rem;
-    border-radius: 0.25rem;
-    transition: 0.2s;
 }
 
-.today:hover {
-    cursor: pointer;
-    background-color: $background-tint;
+.home-top button:hover {
+    border: 0.1rem solid $primary;
+    box-shadow: none;
+    color: $primary;
 }
 
-.dummy-today {
-    display: none;
-    margin-right: 5vw;
-    width: 5.2rem;
+.home-top-item.today {
+    grid-column-start: 2;
 }
 
-.change-month {
-    display: none;
-    font-family: $title-font;
-    background-color: $background;
-    width: 1.3rem;
-    border: 0.1rem solid $text-primary;
-    padding: 0.1rem 0.25rem;
-    font-size: 0.75rem;
-    border-radius: 0.25rem;
-    transition: 0.2s;
+.home-top-item.month-change {
+    padding: 0;
+    border: none;
+    box-shadow: none;
+    font-size: 1.5rem;
 }
 
-.change-month:hover {
-    cursor: pointer;
-    background-color: $background-tint;
+.home-top-item.month-change:hover {
+    border: none;
+    color: $primary;
 }
 
-.month-back {
-    margin-left: 3vw;
+.home-top-item.month-change.backward {
+    grid-column-start: 4;
 }
 
-.month-forward {
-    margin-right: 3vw;
+.home-top-item.month-year {
+    grid-column-start: 5;
+    margin: auto;
+    font-size: 1rem;
 }
 
-.view-switch {
-    text-align: center;
-    background-color: $background;
-    width: 7.7rem;
-    border: 0.1rem solid $text-primary;
-    padding: 0.1rem 0.25rem;
-    font-size: 0.75rem;
-    border-radius: 0.25rem;
-    transition: 0.2s;
-    margin-left: 5vw;
+.home-top-item.month-change.forward {
+    grid-column-start: 6;
 }
 
-.view-switch:hover {
-    cursor: pointer;
-    background-color: $background-tint;
+.home-top-item.view-switch {
+    grid-column-start: 8;
 }
 
-.dummy {
-    display: none;
-    margin-right: 5vw;
-    width: 7.7rem;
+/*
+ * #############################
+ * ##### HOMEPAGE CONTENTS #####
+ * #############################
+ */
+
+.home-schedule-view {
+    margin: 2.5rem 14vw 0 14vw;
+    padding-bottom: 0.5rem;
 }
 
-.view-active {
-    display: block;
+.home-calendar {
+    margin-top: 3rem;
 }
+
+/*
+ * #########################
+ * ##### MEDIA QUERIES #####
+ * #########################
+ */
 
 @include media-small-desktop-down {
     .schedule-view {

--- a/client/src/components/home/home.scss
+++ b/client/src/components/home/home.scss
@@ -90,6 +90,14 @@
     padding-bottom: 0.5rem;
 }
 
+.home-schedule-view-empty {
+    padding-top: 2rem;
+    font-family: $title-font;
+    font-size: 1rem;
+    text-align: center;
+    color: $text-light;
+}
+
 .home-calendar {
     margin-top: 3rem;
 }
@@ -101,32 +109,17 @@
  */
 
 @include media-small-desktop-down {
-    .schedule-view {
-        margin: 2rem 2rem 0;
-    }
-
-    .calendar-header {
-        margin: 1rem 0.5rem 0;
-    }
-
-    .calendar-days {
-        margin: 0 0.5rem 0.5rem;
+    .home-schedule-view {
+        margin: 2.5rem 2rem 0;
     }
 }
 
 @include media-tablet-down {
-    .month-year {
-        font-size: 1rem;
+    .home-top {
+        display: block;
     }
 
-    // Center the month and get rid of view switcher
-    .dummy-change-month,
-    .dummy {
-        display: none;
-        width: 0;
-    }
-
-    .view-switch {
+    .home-top-item.view-switch {
         display: none;
     }
 }
@@ -136,7 +129,7 @@
         top: 2rem;
     }
 
-    .schedule-view {
+    .home-schedule-view {
         margin: 2rem 0.5rem;
     }
 }

--- a/client/src/components/home/home.scss
+++ b/client/src/components/home/home.scss
@@ -25,7 +25,7 @@
     width: 100%;
 
     display: grid;
-    grid-template-columns: 15% 10% 15% 2.5% 20% 2.5% 5% 15% 15%;
+    grid-template-columns: 15% 10% 12.5% 2.5% 20% 2.5% 7.5% 15% 15%;
     align-items: center;
 
     font-family: $title-font;

--- a/client/src/components/home/schedule-event.scss
+++ b/client/src/components/home/schedule-event.scss
@@ -35,6 +35,7 @@
 
 .schedule-event-type-tooltip {
     visibility: hidden;
+    opacity: 0;
     position: absolute;
     z-index: 1;
     bottom: 140%;
@@ -49,6 +50,7 @@
     background-color: $background;
     color: $type-event-darker;
     box-shadow: 0 0 0.4rem $background-tint;
+    transition: 0.3s;
 }
 
 .schedule-event-type-tooltip.signup {
@@ -68,6 +70,7 @@
 
 .schedule-event-type:hover .schedule-event-type-tooltip {
     visibility: visible;
+    opacity: 100%;
 }
 
 .schedule-event-time {

--- a/client/src/components/shared/submit-group.js
+++ b/client/src/components/shared/submit-group.js
@@ -1,18 +1,32 @@
 import React from 'react';
 import ActionButton from './action-button';
-import { returnToLastLocation } from '../../functions/util';
+import { isActive, returnToLastLocation } from '../../functions/util';
 import './submit-group.scss';
 
 class SubmitGroup extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { submitted: false };
+    }
+    submit = async () => {
+        this.setState({ submitted: true });
+        const res = await this.props.submit();
+        if (!res) this.setState({ submitted: false });
+    };
     render() {
         return (
-            <div className={`submit-group ${this.props.className || ''}`}>
-                <ActionButton className="cancel" onClick={returnToLastLocation.bind(this, window.location)}>
-                    Cancel
-                </ActionButton>
-                <ActionButton className="submit" onClick={this.props.submit}>
-                    Submit
-                </ActionButton>
+            <div className={`submit-group ${this.props.className}`}>
+                <div className={isActive('submit-group-buttons', !this.state.submitted)}>
+                    <ActionButton className="cancel" onClick={returnToLastLocation.bind(this, window.location)}>
+                        Cancel
+                    </ActionButton>
+                    <ActionButton className="submit" onClick={this.submit}>
+                        Submit
+                    </ActionButton>
+                </div>
+                <p className={isActive('submit-group-post-message', this.state.submitted)}>
+                    Uploading edits... please do not reload or close this page!
+                </p>
             </div>
         );
     }

--- a/client/src/components/shared/submit-group.scss
+++ b/client/src/components/shared/submit-group.scss
@@ -1,13 +1,26 @@
 @import '../../custom.scss';
 
 .submit-group {
-    display: flex;
+    margin-bottom: 0.5rem;
+}
+
+.submit-group-buttons {
+    display: flex !important;
     flex-direction: row;
     justify-content: flex-end;
-    margin-bottom: 0.5rem;
+}
+
+.submit-group-buttons.inactive {
+    display: none !important;
 }
 
 .submit-group .action-button {
     margin: 0.25rem 0.25rem 0;
     font-size: 1rem;
+}
+
+.submit-group-post-message {
+    text-align: right;
+    font-family: $title-font;
+    color: $text-light;
 }


### PR DESCRIPTION
### Description

Many random cosmetic or quality of life changes:
- Force scrollbar to show on every page (kinda jank solution) to prevent slight shifting when transitioning from not to having a scrollbar
- Added slight tint to every calendar day
- Changed home-top (with the current month/year + switch view buttons) to `display: grid` for set col widths
- Added slight transition to the type tooltip on the home schedule view
- Show a message if there are no upcoming events
- Show a message if clubs don't have committees or execs
- Disable the submit button after user clicks it on the edit pages
- CLEANED UP HOME PAGE SCSS!!!!

### Fixes #257 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request