### PR TITLE
Logo banner just width 100% always

### DIFF
--- a/client/src/components/about/about.scss
+++ b/client/src/components/about/about.scss
@@ -11,7 +11,9 @@
 }
 
 .about-header {
-    height: 6rem;
+    width: 100%;
+    height: auto;
+    object-fit: cover;
     display: block;
     margin: 0 auto 0.5rem;
 }
@@ -62,12 +64,6 @@
 @include media-small-desktop-down {
     .about {
         margin: 1rem 5vw;
-    }
-
-    .about-header {
-        width: 100%;
-        height: auto;
-        object-fit: cover;
     }
 
     #feedback-form {


### PR DESCRIPTION
### Description

Logo banner was weird at a very specific window ratio (less than full desktop but more than tablet), so it will be width 100% and auto-scaled at all resolutions now.

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request