### PR TITLE
Fixed weird center spacing for club cards on mobile

### DIFF
--- a/client/src/components/clubs/clubs.scss
+++ b/client/src/components/clubs/clubs.scss
@@ -19,7 +19,7 @@
 
 @include media-phone-down {
     .club-card-list {
-        padding: 1rem 0 0.5rem;
+        padding: 1rem 2% 0.5rem;
         grid-template-columns: repeat(auto-fill, 50%);
         row-gap: 0.75rem;
         align-items: center;


### PR DESCRIPTION
### Description

aiya

### Fixes #[Issue]

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request