### PR TITLE
Fixed the z-indexes for home page

### DIFF
--- a/client/src/components/home/date-section.scss
+++ b/client/src/components/home/date-section.scss
@@ -8,6 +8,7 @@
     padding: 0.5rem 0;
     font-size: 0.7rem;
     position: sticky;
+    z-index: 1;
     top: 5rem;
     background-color: $background;
     font-family: $title-font;

--- a/client/src/components/home/home.scss
+++ b/client/src/components/home/home.scss
@@ -30,7 +30,7 @@
 
     font-family: $title-font;
     background-color: $background;
-    z-index: 1;
+    z-index: 2;
 }
 
 .home-top button {


### PR DESCRIPTION
### Description

The event type was overlapping with the date section because the date section did not have a defined z-index. The home-top (with the month/year) is now z-index 2, and the date-section will have z-index 1.

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [ ] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request