### PR TITLE
Event information no longer scrolls on popup

### DIFF
--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -123,6 +123,10 @@ a:hover {
     text-align: center;
 }
 
+.fixed {
+    position: fixed;
+}
+
 /*
  * ############################
  * ##### PSEUDO-SELECTORS #####
@@ -194,5 +198,9 @@ a:hover {
 
     .page {
         padding-top: 2rem;
+    }
+
+    .fixed {
+        position: static;
     }
 }

--- a/client/src/components/home/event-popup.js
+++ b/client/src/components/home/event-popup.js
@@ -5,12 +5,7 @@ import ActionButton from '../shared/action-button';
 import { getEvent } from '../../functions/api';
 import { getPopupId, getPopupOpen, getPopupType } from '../../redux/selectors';
 import { resetPopupState } from '../../redux/actions';
-import {
-    addDayjsElement,
-    getFormattedDate,
-    getFormattedTime,
-    parseLinks,
-} from '../../functions/util';
+import { addDayjsElement, getFormattedDate, getFormattedTime, parseLinks } from '../../functions/util';
 
 import './event-popup.scss';
 import Loading from '../shared/loading';
@@ -61,18 +56,20 @@ class EventPopup extends React.Component {
             <div className="event-popup">
                 <div className="event-popup-display">
                     <div className="event-popup-left event-popup-home-side">
-                        {this.state.event.type === 'event' ? (
-                            <p className="event-popup-type event">Event</p>
-                        ) : (
-                            <p className="event-popup-type signup">Signup</p>
-                        )}
-                        <p className="event-popup-name">{this.state.event.name}</p>
-                        <p className="event-popup-club">{this.state.event.club}</p>
-                        <p className="event-popup-date">{getFormattedDate(this.state.event)}</p>
-                        <p className="event-popup-time">{getFormattedTime(this.state.event)}</p>
-                        <ActionButton className="event-popup-open-edit" onClick={this.openEdit}>
-                            Edit
-                        </ActionButton>
+                        <div className="fixed">
+                            {this.state.event.type === 'event' ? (
+                                <p className="event-popup-type event">Event</p>
+                            ) : (
+                                <p className="event-popup-type signup">Signup</p>
+                            )}
+                            <p className="event-popup-name">{this.state.event.name}</p>
+                            <p className="event-popup-club">{this.state.event.club}</p>
+                            <p className="event-popup-date">{getFormattedDate(this.state.event)}</p>
+                            <p className="event-popup-time">{getFormattedTime(this.state.event)}</p>
+                            <ActionButton className="event-popup-open-edit" onClick={this.openEdit}>
+                                Edit
+                            </ActionButton>
+                        </div>
                     </div>
                     <div className="event-popup-right event-popup-home-side">{description}</div>
                 </div>


### PR DESCRIPTION
### Description

The left side of the events popup will no longer scroll when the description needs to be scrolled down. The mobile view will remain the same.

### Fixes #290 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request