### PR TITLE
Added min height to popup

### DIFF
--- a/client/src/components/home/event-popup.scss
+++ b/client/src/components/home/event-popup.scss
@@ -29,6 +29,7 @@
 }
 
 .event-popup-left {
+    min-height: 8rem;
     border-right: 0.03rem solid $text-primary;
 }
 


### PR DESCRIPTION
### Description

The previous pull request made the left side fixed, which meant that if the descriptiojn was too short, the container wouldn't expand enough to fit the fixed content. To solve this, I simply added a `min-height` attribute to the entire container.

### Fixes #293 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [ ] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [ ] I have **fully** commented my code, especially in hard-to-understand areas
- [ ] I have made changes to the documentation OR created an issue to update documentation
- [ ] All existing functionality (if a non-breaking change) still works as it should
- [ ] I have assigned at least one person to review my pull request

### Reference Image
![bloop](https://user-images.githubusercontent.com/37679458/111812912-93c45b80-88a6-11eb-81f5-5f1409926f1a.png)
