### PR TITLE
Change media queries to only min-width

### DIFF
--- a/client/src/custom.scss
+++ b/client/src/custom.scss
@@ -35,19 +35,19 @@ $filter-open: #82ee9a;
 // Media Queries
 
 @mixin media-small-desktop-down {
-    @media handheld and (max-width: 1200px), screen and (max-device-width: 1200px), screen and (max-width: 1200px) {
+    @media only screen and (max-width: 1200px) {
         @content;
     }
 }
 
 @mixin media-tablet-down {
-    @media handheld and (max-width: 992px), screen and (max-device-width: 992px), screen and (max-width: 992px) {
+    @media only screen and (max-width: 992px) {
         @content;
     }
 }
 
 @mixin media-phone-down {
-    @media handheld and (max-width: 652px), screen and (max-device-width: 652px), screen and (max-width: 652px) {
+    @media only screen and (max-width: 652px) {
         @content;
     }
 }


### PR DESCRIPTION
### Description

Before, the css would check for `max-device-width`, completely ignoring the `Show Desktop View`'s width changes. By reducing this to only `max-width`, the screen will now render as a desktop view when set.

### Fixes #295 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request