### PR TITLE
Add transition and border radius to calendar events

### DIFF
--- a/client/src/components/home/calendar-event.scss
+++ b/client/src/components/home/calendar-event.scss
@@ -15,6 +15,9 @@
 
     font-family: $alt-font;
     font-weight: 800;
+
+    border-radius: 0.2rem;
+    transition: 0.2s;
 }
 
 .calendar-event:hover {


### PR DESCRIPTION
### Description

Add a transition of of 0.2s and a border radius of 0.2rem to calendar events.

### Fixes #297 

### Type of change

Delete options that do not apply:

- New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request