### PR TITLE
Fixed dark theme for volunteering cards

### DIFF
--- a/client/src/components/volunteering/volunteering-card.js
+++ b/client/src/components/volunteering/volunteering-card.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { formatVolunteeringFilters } from '../../functions/util';
+import { formatVolunteeringFilters, isActive } from '../../functions/util';
 import './volunteering-card.scss';
 
 class VolunteeringCard extends React.Component {
@@ -8,7 +8,8 @@ class VolunteeringCard extends React.Component {
         var filterObjects = formatVolunteeringFilters(this.props.vol.filters, this.props.vol.signupTime);
         return (
             <div className="volunteering-card" onClick={this.props.onClick}>
-                <div className={'volunteering-card-overlay' + (!this.props.vol.filters.open ? ' overlay-closed' : '')}>
+                <div className={isActive('volunteering-card-overlay', !this.props.vol.filters.open)}></div>
+                <div className="volunteering-card-content">
                     <div
                         className={
                             'volunteering-card-status status ' + (this.props.vol.filters.open ? 'open' : 'closed')

--- a/client/src/components/volunteering/volunteering-card.scss
+++ b/client/src/components/volunteering/volunteering-card.scss
@@ -1,27 +1,46 @@
+/**
+ * The volunteering card contains the information for a specific volunteering:
+ *
+ * 1) The card will be red if it is closed
+ * 2) On hover, the box shadow will increase slightly
+ * 3) The volunteering filters at the bottom are colored to match a filter
+ */
+
 @import '../../custom.scss';
 
+// Relative positioning for the overlay to use absolute positioning
 .volunteering-card {
-    background-color: $background;
-    box-shadow: 0 0 0.3rem $background-tint;
-    text-align: center;
+    position: relative;
     width: 9rem;
     height: 7.5rem;
+
+    box-shadow: 0 0 0.3rem $background-tint;
+    text-align: center;
+    background-color: $background;
+    cursor: pointer;
     transition: 0.3s;
 }
 
 .volunteering-card:hover {
-    cursor: pointer;
     box-shadow: 0 0 0.2rem 0.1rem $background-dark;
 }
 
 .volunteering-card-overlay {
-    padding: 0.25rem;
-    width: 8.5rem;
-    height: 7rem;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background-color: #00000033;
 }
 
-.volunteering-card-overlay.overlay-closed {
-    background-color: #00000033;
+// Red tint on closed cards for dark theme
+.dark .volunteering-card-overlay {
+    background-color: #FF000010;
+}
+
+.volunteering-card-content {
+    width: 8.5rem;
+    height: 7rem;
+    padding: 0.25rem;
 }
 
 .volunteering-card-status {


### PR DESCRIPTION
### Description

Dark theme now works for volunteering cards' open filter. On dark theme, it will be tinted red!

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request