### PR TITLE
Fix the width of the events popup and expand height

### DIFF
--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -205,10 +205,6 @@ a:hover {
     text-align: center;
 }
 
-.fixed {
-    position: fixed;
-}
-
 /*
  * ############################
  * ##### PSEUDO-SELECTORS #####
@@ -280,9 +276,5 @@ a:hover {
 
     .page {
         padding-top: 2rem;
-    }
-
-    .fixed {
-        position: static;
     }
 }

--- a/client/src/components/home/event-popup.js
+++ b/client/src/components/home/event-popup.js
@@ -56,7 +56,7 @@ class EventPopup extends React.Component {
             <div className="event-popup">
                 <div className="event-popup-display">
                     <div className="event-popup-left event-popup-home-side">
-                        <div className="fixed">
+                        <div className="event-popup-fixed-container">
                             {this.state.event.type === 'event' ? (
                                 <p className="event-popup-type event">Event</p>
                             ) : (

--- a/client/src/components/home/event-popup.scss
+++ b/client/src/components/home/event-popup.scss
@@ -28,8 +28,13 @@
 }
 
 .event-popup-left {
-    min-height: 8rem;
+    min-height: 10rem;
     border-right: 0.03rem solid $text-primary;
+}
+
+.event-popup-fixed-container {
+    position: fixed;
+    width: 11.5rem;
 }
 
 /*
@@ -110,6 +115,10 @@
     .event-popup-left {
         border: none;
         border-bottom: 0.03rem solid $text-primary;
+    }
+
+    .event-popup-fixed-container {
+        position: static;
     }
 
     .event-popup-type {


### PR DESCRIPTION
### Description

Added fixed width on the events popup left side that was set to `position: absolute` before. To accommodate for most overflowed titles, the min height of the entire popup is increased. 

### Fixes #306 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request