### PR TITLE
Dark Mode Cookies!

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -16,6 +16,7 @@ import './app.scss';
 import Resources from './components/resources/resources';
 import Auth from './components/edit/auth';
 import ActionButton from './components/shared/action-button';
+import Cookies from 'universal-cookie';
 
 class App extends React.Component {
     constructor(props) {
@@ -24,8 +25,18 @@ class App extends React.Component {
     }
 
     toggleDarkTheme = () => {
+        const cookies = new Cookies();
+        cookies.set('dark', !this.state.dark, { path: '/', sameSite: 'strict' });
         this.setState({ dark: !this.state.dark });
     };
+
+    componentDidMount() {
+        const cookies = new Cookies();
+        const dark = cookies.get('dark');
+        if (dark === undefined || dark === 'false') return;
+        else this.setState({ dark: true });
+    }
+
     render() {
         return (
             <div className={`App ${this.state.dark ? 'dark' : ''}`}>

--- a/client/src/components/shared/icon-group.scss
+++ b/client/src/components/shared/icon-group.scss
@@ -9,7 +9,7 @@
 // globe-style, fb-icon, and web-icon are defined classes in their respective svg files
 .globe-style {
     fill: none;
-    stroke: #231f20;
+    stroke: $text-primary;
     stroke-linejoin: round;
     stroke-width: 30px;
 }


### PR DESCRIPTION
### Description

- Dark mode settings will be saved through cookies and won't reset on site reload
- Fixed globe display on dark theme

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request