### PR TITLE
Added max height to name to guarantee no clipping

### DIFF
--- a/client/src/components/home/event-popup.scss
+++ b/client/src/components/home/event-popup.scss
@@ -60,6 +60,7 @@
 .event-popup-name {
     width: 100%;
     max-width: 100%;
+    max-height: 5.25rem;
     margin-bottom: -0.1rem;
     overflow: hidden;
     


### PR DESCRIPTION
### Description

Prevents this:
![image](https://user-images.githubusercontent.com/37679458/111936256-4f49e300-8a93-11eb-89f9-04ae0a57f26c.png)

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request