### PR TITLE
Added text to diff between staging and production apps

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -17,6 +17,7 @@ import Resources from './components/resources/resources';
 import Auth from './components/edit/auth';
 import ActionButton from './components/shared/action-button';
 import Cookies from 'universal-cookie';
+import { isActive } from './functions/util';
 
 class App extends React.Component {
     constructor(props) {
@@ -38,6 +39,7 @@ class App extends React.Component {
     }
 
     render() {
+        const isStaging = window.location.origin !== 'https://tams.club';
         return (
             <div className={`App ${this.state.dark ? 'dark' : ''}`}>
                 <BrowserRouter>
@@ -48,6 +50,7 @@ class App extends React.Component {
                     >
                         !
                     </ActionButton>
+                    <p className={isActive('staging-text', isStaging)}>STAGING</p>
                     <RoutingRequests />
                     <Menu />
                     <div className="page">

--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -152,6 +152,15 @@ a:hover {
     left: 1rem;
 }
 
+.staging-text {
+    position: fixed;
+    top: 0.75rem;
+    left: 1rem;
+    color: $bad;
+    font-family: $title-font;
+    z-index: 101;
+}
+
 /*
  * ###############################
  * ##### GENERAL USE CLASSES #####
@@ -244,6 +253,11 @@ a:hover {
     html {
         font-size: 32px;
     }
+
+    .staging-text {
+        left: 0.5rem;
+        font-size: 0.6rem;
+    }
 }
 
 @include media-tablet-down {
@@ -276,5 +290,9 @@ a:hover {
 
     .page {
         padding-top: 2rem;
+    }
+
+    .staging-text {
+        left: 3rem;
     }
 }


### PR DESCRIPTION
### Description

Red text at the top of the staging app shows that it's staging vs. the production version. 
![image](https://user-images.githubusercontent.com/37679458/112727703-c21ee800-8ef1-11eb-9c9d-fe6e43a715b1.png)

### Type of change

Delete options that do not apply:

- New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request