### PR TITLE
Popup fixes

### DIFF
--- a/client/src/components/clubs/club-card.scss
+++ b/client/src/components/clubs/club-card.scss
@@ -80,9 +80,12 @@
 
 .club-card-name {
     padding: 0 0.25rem;
+    max-height: 1.95rem;
+    overflow: hidden;
 
     font-size: 0.65rem;
     font-family: $title-font;
+    line-height: 0.65rem;
     color: $text-primary;
 }
 

--- a/client/src/components/clubs/club-popup.scss
+++ b/client/src/components/clubs/club-popup.scss
@@ -182,10 +182,6 @@
         margin-top: 0.5rem;
     }
 
-    .club-popup-edit-button {
-        display: none;
-    }
-
     .club-popup-tab-item {
         font-size: 1.25rem;
     }

--- a/client/src/components/clubs/club-popup.scss
+++ b/client/src/components/clubs/club-popup.scss
@@ -190,8 +190,8 @@
         font-size: 1.25rem;
     }
 
-    .club-popup-committees {
-        display: flex;
+    .club-popup-committees-list {
+        display: flex !important;
         flex-direction: column;
         align-items: center;
     }

--- a/client/src/components/clubs/committee-card.scss
+++ b/client/src/components/clubs/committee-card.scss
@@ -17,6 +17,8 @@
 
 .committee-card-name {
     padding: 0.25rem 0.5rem;
+    overflow-x: hidden;
+    
     font-size: 0.85rem;
     font-family: $title-font;
     font-weight: 300;

--- a/client/src/components/clubs/exec-card.scss
+++ b/client/src/components/clubs/exec-card.scss
@@ -10,9 +10,10 @@
 @import '../../custom.scss';
 
 .exec-card {
+    margin: 0 2rem 1rem 2rem;
     display: flex;
     flex-direction: row;
-    margin: 0 2rem 1rem 2rem;
+    text-align: left;
 }
 
 /*

--- a/client/src/components/clubs/exec-card.scss
+++ b/client/src/components/clubs/exec-card.scss
@@ -55,18 +55,15 @@
 .exec-card-name {
     max-width: 50%;
     overflow-x: hidden;
-    white-space: nowrap;
 }
 
 .exec-card-position {
     max-width: 50%;
     padding-left: 0.75rem;
     padding-bottom: 0.1rem;
-    overflow: hidden;
+    overflow-x: hidden;
 
     font-size: 0.6rem;
-    white-space: nowrap;
-    text-overflow: ellipsis;
     color: $text-lighter;
 }
 

--- a/client/src/components/edit/edit-clubs.scss
+++ b/client/src/components/edit/edit-clubs.scss
@@ -149,3 +149,15 @@
     margin-top: 0 !important;
     flex-grow: 0;
 }
+
+/*
+ * #########################
+ * ##### MEDIA QUERIES #####
+ * #########################
+ */
+
+ @include media-phone-down {
+    .edit-clubs {
+        margin: 1rem 0.1rem 0;
+    }
+}

--- a/client/src/components/home/event-popup.scss
+++ b/client/src/components/home/event-popup.scss
@@ -23,17 +23,16 @@
 
 .event-popup-home-side {
     flex-basis: 50%;
-    overflow-x: hidden;
     padding: 0.5rem;
 }
 
 .event-popup-left {
-    min-height: 10rem;
     border-right: 0.03rem solid $text-primary;
 }
 
 .event-popup-fixed-container {
-    position: fixed;
+    position: sticky;
+    top: 1rem;
     width: 11.5rem;
 }
 
@@ -59,10 +58,8 @@
 
 .event-popup-name {
     width: 100%;
-    max-width: 100%;
-    max-height: 5.25rem;
+    overflow-x: auto;
     margin-bottom: -0.1rem;
-    overflow: hidden;
     
     font-size: 1.1rem;
     font-family: $title-font;

--- a/client/src/components/home/event-popup.scss
+++ b/client/src/components/home/event-popup.scss
@@ -104,6 +104,7 @@
     .event-popup {
         width: 90vw;
         padding: 5vw;
+        padding-bottom: 20vw;
     }
 
     .event-popup-display {

--- a/client/src/components/shared/popup.js
+++ b/client/src/components/shared/popup.js
@@ -23,7 +23,7 @@ class Popup extends React.Component {
 
     render() {
         return (
-            <div className={`popup ${isActive('', this.props.open)} ${this.props.noscroll ? 'noscroll' : ''}`}>
+            <div className={`popup ${isActive('', this.props.open)}`}>
                 <div className="popup-close-bkgd" onClick={this.close}></div>
                 <div className="popup-content">{this.props.children}</div>
                 <button className="popup-close-button" onClick={this.close}>

--- a/client/src/components/shared/popup.scss
+++ b/client/src/components/shared/popup.scss
@@ -39,10 +39,6 @@
     box-shadow: 0 0 3px $text-light;
 }
 
-.popup.noscroll .popup-content {
-    overflow-y: hidden !important;
-}
-
 .popup-close-button {
     display: none;
     position: fixed;

--- a/client/src/components/volunteering/volunteering-card.scss
+++ b/client/src/components/volunteering/volunteering-card.scss
@@ -56,7 +56,8 @@
     color: $bad;
 }
 
-.volunteering-card-name {
+.volunteering-card-name,
+.volunteering-card-club-name {
     margin: 0.1rem;
     font-family: $title-font;
     font-size: 0.9rem;
@@ -69,8 +70,6 @@
 .volunteering-card-club-name {
     color: $text-light;
     font-size: 0.6rem;
-    font-family: $title-font;
-    font-weight: 300;
 }
 
 .volunteering-card-description {

--- a/client/src/components/volunteering/volunteering-popup.js
+++ b/client/src/components/volunteering/volunteering-popup.js
@@ -47,27 +47,27 @@ class VolunteeringPopup extends React.Component {
     render() {
         // Return 'loading' if the current popup is not defined
         if (this.state.vol === null || this.state.vol === undefined)
-            return <Loading className="VolunteeringPopup"></Loading>;
+            return <Loading className="volunteering-popup"></Loading>;
 
         // Get a list of filters
         const filters = formatVolunteeringFilters(this.state.vol.filters, this.state.vol.signupTime);
 
         // Parse description links
-        const description = parseLinks('res-popup-description', this.state.vol.description);
+        const description = parseLinks('vol-popup-description', this.state.vol.description);
 
         return (
-            <div className="VolunteeringPopup">
+            <div className="volunteering-popup">
                 <div className={'display' + (!this.props.edit ? ' active' : ' inactive')}>
                     {this.state.vol.filters.open ? (
-                        <p className="res-popup-open open">Open</p>
+                        <p className="vol-popup-open open">Open</p>
                     ) : (
-                        <p className="res-popup-open closed">Closed</p>
+                        <p className="vol-popup-open closed">Closed</p>
                     )}
-                    <p className="res-popup-name">{this.state.vol.name}</p>
-                    <p className="res-popup-club">{this.state.vol.club}</p>
+                    <p className="vol-popup-name">{this.state.vol.name}</p>
+                    <p className="vol-popup-club">{this.state.vol.club}</p>
                     {description}
                     {filters}
-                    <ActionButton className="res-popup-edit" onClick={this.openEdit}>
+                    <ActionButton className="vol-popup-edit" onClick={this.openEdit}>
                         Edit
                     </ActionButton>
                 </div>

--- a/client/src/components/volunteering/volunteering-popup.scss
+++ b/client/src/components/volunteering/volunteering-popup.scss
@@ -5,56 +5,49 @@
 
 @import '../../custom.scss';
 
-.VolunteeringPopup {
-    text-align: center;
+.volunteering-popup {
     padding: 0.5rem;
     width: 14rem;
+    overflow-x: auto;
+    text-align: center;
 }
 
-.VolunteeringPopup .filter {
+.volunteering-popup .filter {
     font-size: 0.65rem;
 }
 
-.res-popup-open {
+.vol-popup-open {
     font-size: 0.65rem;
 }
 
-.res-popup-open.open {
+.vol-popup-open.open {
     color: $primary;
 }
 
-.res-popup-open.closed {
+.vol-popup-open.closed {
     color: $bad;
 }
 
-.res-popup-name {
+.vol-popup-name {
     font-size: 1.25rem;
     font-family: $title-font;
     font-weight: 300;
 }
 
-.res-popup-club {
+.vol-popup-club {
     font-size: 0.9rem;
     font-family: $title-font;
     font-weight: 300;
     color: $text-light;
 }
 
-.res-popup-description {
+.vol-popup-description {
     font-size: 0.65rem;
     white-space: pre-line;
 }
 
-.VolunteeringPopup .action-button {
+.volunteering-popup .action-button {
     margin-top: 0.5rem;
-}
-
-.VolunteeringPopup .inactive {
-    display: none;
-}
-
-.VolunteeringPopup .active {
-    display: block;
 }
 
 /*
@@ -64,7 +57,7 @@
  */
 
 @include media-phone-down {
-    .VolunteeringPopup {
+    .volunteering-popup {
         width: 90vw;
         padding: 5vw;
         padding-bottom: 10vw;

--- a/client/src/components/volunteering/volunteering-popup.scss
+++ b/client/src/components/volunteering/volunteering-popup.scss
@@ -60,6 +60,6 @@
     .volunteering-popup {
         width: 90vw;
         padding: 5vw;
-        padding-bottom: 10vw;
+        padding-bottom: 20vw;
     }
 }

--- a/client/src/components/volunteering/volunteering.js
+++ b/client/src/components/volunteering/volunteering.js
@@ -52,7 +52,7 @@ class Volunteering extends React.Component {
 
         return (
             <div className="Resources">
-                <Popup history={this.props.history} noscroll>
+                <Popup history={this.props.history}>
                     <VolunteeringPopup></VolunteeringPopup>
                 </Popup>
                 <AddButton type="Volunteering"></AddButton>


### PR DESCRIPTION
### Description

- Events popup: All event names and club names are displayed in full + popup now scales correctly due to STICKY!!!!
- Volunteering card: Club names no longer overflow
- Volunteering popup: Can now scroll
- Club card: Names will no longer overflow
- Club popup: Exec and committee full names will now show
- Club popup: Fixed weird spacing of committees on mobile
- Club popup: All text on exec cards are left aligned
- Club popup: Now the editing button is visible on mobile
- Popups: Bottom of all popups are now fully visible on mobile!

### Fixes #291
### Fixes #302
### Fixes #313
### Fixes #314

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request