### PR TITLE
No expand add button on mobile

### DIFF
--- a/client/src/components/shared/add-button.scss
+++ b/client/src/components/shared/add-button.scss
@@ -58,3 +58,15 @@
     font-weight: 300;
     color: $primary;
 }
+
+/*
+ * #########################
+ * ##### MEDIA QUERIES #####
+ * #########################
+ */
+
+@include media-tablet-down {
+    .add-button:hover {
+        width: 2rem !important;
+    }
+}


### PR DESCRIPTION
### Description

The 'add' button will not expand on the mobile view

### Fixes #311 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request