### PR TITLE
Fixed club image upload to be always centered

### DIFF
--- a/client/src/components/edit/edit-clubs.scss
+++ b/client/src/components/edit/edit-clubs.scss
@@ -17,9 +17,10 @@
     margin: 1rem 2rem 0;
 }
 
+// Image will always be at a 36:15 scale ratio of w:h
 .edit-clubs-image {
-    width: 36rem;
-    height: 15rem;
+    width: 90vw;
+    height: calc(90vw * 15 / 36);
     margin: auto;
     display: block;
     object-fit: cover;


### PR DESCRIPTION
### Description

The image upload container (edit-clubs) on views that were not desktop always overflowed and caused weird spacing issues. This will dynamically calculate the height of this box as to keep the 36:15 image scale ratio.

### Fixes #300

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request