### PR TITLE
Added check for default dark theme

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -34,8 +34,13 @@ class App extends React.Component {
     componentDidMount() {
         const cookies = new Cookies();
         const dark = cookies.get('dark');
-        if (dark === undefined || dark === 'false') return;
-        else this.setState({ dark: true });
+        const defaultDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (dark === undefined) {
+            if (defaultDark) {
+                cookies.set('dark', true, { path: '/', sameSite: 'strict' });
+                this.setState({ dark: true });
+            }
+        } else if (dark === 'true') this.setState({ dark: true });
     }
 
     render() {


### PR DESCRIPTION
### Description

If the client's system has dark theme enabled, then the site will automatically enable dark theme upon 1st visit. This can be manually disabled afterwards.

### Fixes #310 

### Type of change

Delete options that do not apply:

- New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request