### PR TITLE
Fix width of right side of event popup

### DIFF
--- a/client/src/components/home/event-popup.scss
+++ b/client/src/components/home/event-popup.scss
@@ -22,12 +22,16 @@
 }
 
 .event-popup-home-side {
-    flex-basis: 50%;
     padding: 0.5rem;
+    flex-basis: 50%;
 }
 
 .event-popup-left {
     border-right: 0.03rem solid $text-primary;
+}
+
+.event-popup-right {
+    width: calc(50% - 0.5rem);
 }
 
 .event-popup-fixed-container {
@@ -89,9 +93,9 @@
 }
 
 .event-popup-description {
-    padding-right: 0.5rem;
     font-size: 0.55rem;
     white-space: pre-line;
+    overflow-x: hidden;
 }
 
 /*


### PR DESCRIPTION
### Description

Fixed this:
![image](https://user-images.githubusercontent.com/37679458/112883310-b9feae00-9093-11eb-9236-3ac5cbc2c1ea.png)

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [ ] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [ ] I have **fully** commented my code, especially in hard-to-understand areas
- [ ] I have made changes to the documentation OR created an issue to update documentation
- [ ] All existing functionality (if a non-breaking change) still works as it should
- [ ] I have assigned at least one person to review my pull request