### PR TITLE
Added media query to fix weird width on mobile

### DIFF
--- a/client/src/components/home/event-popup.scss
+++ b/client/src/components/home/event-popup.scss
@@ -124,6 +124,10 @@
         position: static;
     }
 
+    .event-popup-right {
+        width: auto;
+    }
+
     .event-popup-type {
         font-size: 0.75rem;
     }


### PR DESCRIPTION
### Description

After #323, the mobile view still had the fixed width of the desktop view on the right side of the event popup. I fixed this by adding a media query which set the offending value to `width: auto`.

### Fixes #324 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request