### PR TITLE
Redirect when clicking edit/add button

### DIFF
--- a/client/src/components/shared/add-button.js
+++ b/client/src/components/shared/add-button.js
@@ -15,6 +15,7 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
+// TODO: Add a tooltip to the floating action button
 /**
  * Shows a floating action button
  * @param {object} props React props object

--- a/client/src/components/shared/add-button.js
+++ b/client/src/components/shared/add-button.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useHistory } from 'react-router';
+import { redirect } from '../../functions/util';
 
 import Fab from '@material-ui/core/Fab';
 import AddIcon from '@material-ui/icons/Add';
@@ -23,18 +23,17 @@ const useStyles = makeStyles((theme) => ({
  * @param {boolean} [props.edit] If true, will show edit button or else it'll show the add button
  */
 const AddButton = (props) => {
-    const history = useHistory();
     const classes = useStyles();
 
-    const redirect = () => {
-        history.push(props.path);
+    const redirectTo = () => {
+        redirect(props.path);
     };
 
     return (
         <Fab
             color={props.color || 'default'}
             aria-label={props.edit ? 'edit' : 'add'}
-            onClick={redirect}
+            onClick={redirectTo}
             className={classes.root}
         >
             {props.edit ? <EditIcon /> : <AddIcon />}


### PR DESCRIPTION
### Description

Login with google button wasn't showing up because it's dynamically loaded. Best solution is to use redirect and reload the page when editing.

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request