### PR TITLE
Fixed staging app uploading images to the wrong S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ AWS_ACCESS_ID="[AWS IAM User Access Key ID]"
 AWS_SECRET_KEY="[AWS IAM User Secret Key]"
 
 ORIGIN="[(optional) Origin requests are sent from. This is needed for google login -- thus, it will not work for local development]"
-NO_ORIGIN_CHECK="[(optional) If true, all requests not from ORIGIN will be *denied with a 403 error*]
+NO_ORIGIN_CHECK="[(optional) If true, all requests not from ORIGIN will be *denied with a 403 error*]"
+STAGING="[(optional) On dev.tams.club, this value needs to be true to upload files to the correct bucket due to docker running in production]"
 PORT="[(optional) The port to start the server on]"
 ```
 

--- a/server/src/functions/images.js
+++ b/server/src/functions/images.js
@@ -9,7 +9,7 @@ const s3 = new AWS.S3({
     accessKeyId: process.env.AWS_ACCESS_ID,
     secretAccessKey: process.env.AWS_SECRET_KEY,
 });
-const BUCKET = `${process.env.NODE_ENV === 'production' ? '' : 'staging-'}tams-club-calendar-images`;
+const BUCKET = `${process.env.NODE_ENV === 'production' && !process.env.STAGING ? '' : 'staging-'}tams-club-calendar-images`;
 
 /**
  * Will compress, resize, and upload all images passed to a club upload.


### PR DESCRIPTION
### Description

Staging app was pushing images to the wrong S3 bucket due to the fact that docker will run the app in `NODE_ENV=production`. This issue was fixed by adding an extra environmental variable that would manually set the bucket to the staging one.

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request