### PR TITLE
Fixed issue where site crashes when user goes from table view to and from a resource

### DIFF
--- a/client/src/components/clubs/club-table.js
+++ b/client/src/components/clubs/club-table.js
@@ -11,6 +11,7 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import Image from '../shared/image';
+import Loading from '../shared/loading';
 
 /**
  * Displays the clubs in a table. The clubs prop will be mapped to table rows.
@@ -20,7 +21,9 @@ import Image from '../shared/image';
  * @param {Club[]} props.clubs Club list
  */
 const ClubTable = (props) => {
-    return (
+    return props.clubs === null ? (
+        <Loading />
+    ) : (
         <TableContainer component={Paper} sx={{ marginBottom: 4 }}>
             <Table aria-label="club table">
                 <TableHead>

--- a/client/src/components/volunteering/volunteering-table.js
+++ b/client/src/components/volunteering/volunteering-table.js
@@ -14,6 +14,7 @@ import DashboardRoundedIcon from '@mui/icons-material/DashboardRounded';
 import EventNoteRoundedIcon from '@mui/icons-material/EventNoteRounded';
 import ScheduleRoundedIcon from '@mui/icons-material/ScheduleRounded';
 import EventRoundedIcon from '@mui/icons-material/EventRounded';
+import Loading from '../shared/loading';
 
 /**
  * Displays the volunteering opportunities in a table
@@ -22,7 +23,9 @@ import EventRoundedIcon from '@mui/icons-material/EventRounded';
  * @param {Volunteering[]} props.volunteering Volunteering list
  */
 const VolunteeringTable = (props) => {
-    return (
+    return props.volunteering === null ? (
+        <Loading />
+    ) : (
         <TableContainer component={Paper} sx={{ marginBottom: 8 }}>
             <Table aria-label="volunteering table">
                 <TableHead>
@@ -40,7 +43,7 @@ const VolunteeringTable = (props) => {
                     {props.volunteering.map((v) => (
                         <TableRow
                             component={Link}
-                            to={`/volunteering?id=${v.id}&view=list`}
+                            to={`/volunteering?id=${v.id}&view=table`}
                             sx={{
                                 textDecoration: 'none',
                                 color: 'inherit',


### PR DESCRIPTION
### Description

Back button is broken when you go from table view -> individual club and then click the back button at the bottom of the club page. This also happens on the volunteering elements! However, this has been fixed by waiting for props.clubs to update before rendering the table.

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [ ] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [ ] I have **fully** commented my code, especially in hard-to-understand areas
- [ ] I have made changes to the documentation OR created an issue to update documentation
- [ ] All existing functionality (if a non-breaking change) still works as it should
- [ ] I have assigned at least one person to review my pull request