### PR TITLE
Fixed catch for invalid edit history resource

### DIFF
--- a/client/src/components/edit/history/history-display.js
+++ b/client/src/components/edit/history/history-display.js
@@ -35,8 +35,6 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-// TODO: Check to see if the object is valid!!!!!!!!!!!!!!!!
-
 /**
  * Displays a list of history entries for a specific object.
  * /edit/history/:resource will route to this component.
@@ -51,6 +49,7 @@ const HistoryDisplay = (props) => {
     const [components, setComponents] = useState(null);
     const [currHistory, setCurrHistory] = useState(null);
     const [popupOpen, setPopupOpen] = useState(false);
+    const [error, setError] = useState(false);
     const resource = props.match.params.resource;
     const location = useLocation();
     const classes = useStyles();
@@ -67,9 +66,7 @@ const HistoryDisplay = (props) => {
         // Make the API call and handle errors
         const history = await getHistory(resource, queryId);
         if (history.status !== 200) {
-            setComponents(
-                <Loading error>Invalid {resource} ID. Please return to the home page and check the ID.</Loading>
-            );
+            setError(true);
             return;
         }
 
@@ -131,7 +128,15 @@ const HistoryDisplay = (props) => {
     return (
         <TableContainer>
             {components === null ? (
-                <Loading />
+                error ? (
+                    <Loading error flat>
+                        Invalid {resource} ID. Please return to the home page and check the ID. The resource you are
+                        trying to see the edit history for might be deleted. Please contact the site administrator if
+                        you believe that this error is incorrect.
+                    </Loading>
+                ) : (
+                    <Loading />
+                )
             ) : (
                 <React.Fragment>
                     <Title editHistory resource={resource} name={name} />


### PR DESCRIPTION
### Description

Instead of rendering the main data, the edit history page will check for errors before and render an error message if it cannot get the edit history of the given resource.

### Fixes #361 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [ ] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [ ] I have **fully** commented my code, especially in hard-to-understand areas
- [ ] I have made changes to the documentation OR created an issue to update documentation
- [ ] All existing functionality (if a non-breaking change) still works as it should
- [ ] I have assigned at least one person to review my pull request