### PR TITLE
Fixed volunteering open filter change

### DIFF
--- a/client/src/components/edit/edit-volunteering.js
+++ b/client/src/components/edit/edit-volunteering.js
@@ -66,7 +66,7 @@ const EditVolunteering = () => {
             data.name,
             data.club,
             data.description,
-            new Filters(data.limited, data.semester, data.setTimes, data.weekly, data.open === 'open'),
+            new Filters(data.limited, data.semester, data.setTimes, data.weekly, data.open),
             volunteering.history
         );
 


### PR DESCRIPTION
### Description

The issue was that this field was previously a select, so the code was checking if that select field contained the text "open". Unfortunately, now it is a switch, so that variable would store a boolean value, meaning that we no longer have to check if its equal to "open".

### Fixes #360 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [ ] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [ ] I have **fully** commented my code, especially in hard-to-understand areas
- [ ] I have made changes to the documentation OR created an issue to update documentation
- [ ] All existing functionality (if a non-breaking change) still works as it should
- [ ] I have assigned at least one person to review my pull request