### PR TITLE
Fixed timezone for alpine docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,11 @@ COPY server ./
 COPY --from=deps /app/node_modules ./node_modules
 RUN yarn build:backend
 
-# Production image, copy all the files and run next
+# Production image, copy all the files and run apps
 FROM node:16-alpine AS runner
 WORKDIR /app/client
+RUN apk add --no-cache tzdata
+RUN cp /usr/share/zoneinfo/America/Chicago /etc/localtime
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
### Description

Calendar dates were off due to incorrect server timezone. This fixes the issue with the calendar not showing the right month between 6pm and midnight (due to America/Chicago being UTC-6). This only changes the Dockerfile, so a recompilation of container is needed to be fixed.

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [ ] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [ ] I have **fully** commented my code, especially in hard-to-understand areas
- [ ] I have made changes to the documentation OR created an issue to update documentation
- [ ] All existing functionality (if a non-breaking change) still works as it should
- [ ] I have assigned at least one person to review my pull request