### PR TITLE
Added calendar "Today" button

### DIFF
--- a/client/pages/events/calendar/[[...date]].tsx
+++ b/client/pages/events/calendar/[[...date]].tsx
@@ -8,6 +8,7 @@ import { getPublicEventListInRange } from '../../../src/api';
 
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
+import Button from '@mui/material/Button';
 import ArrowBackIosRoundedIcon from '@mui/icons-material/ArrowBackIosRounded';
 import ArrowForwardIosRoundedIcon from '@mui/icons-material/ArrowForwardIosRounded';
 import HomeBase from '../../../src/components/home/home-base';
@@ -127,6 +128,11 @@ const Calendar = (props: InferGetServerSidePropsType<typeof getServerSideProps>)
         router.push(`/events/calendar/${newMonth.format('YYYY/M')}`);
     };
 
+    // Go to the current month when today button is clicked
+    const goToToday = () => {
+        router.push(`/events/calendar/${dayjs().format('YYYY/M')}`);
+    }
+
     // Create the days of the week as the header
     const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
     const calendarHeaderList = days.map((date) => (
@@ -144,9 +150,14 @@ const Calendar = (props: InferGetServerSidePropsType<typeof getServerSideProps>)
 
     return (
         <HomeBase unsetHeight>
-            <Box display="flex" flexDirection="column" sx={{ flexGrow: 1 }}>
+            <Box display="flex" flexDirection="column" sx={{ flexGrow: 1, marginBottom: 1 }}>
                 <AddButton color="primary" label="Event" path="/edit/events" />
                 <Box width="100%" display="flex" justifyContent="center" alignItems="center">
+                    <Box sx={{ flex: 1, display: 'flex', justifyContent: 'right' }}>
+                        <Button variant="outlined" sx={{ marginRight: 4 }} onClick={goToToday}>
+                            Today
+                        </Button>
+                    </Box>
                     <IconButton size="small" onClick={offsetMonth.bind(this, false)}>
                         <ArrowBackIosRoundedIcon />
                     </IconButton>
@@ -156,6 +167,7 @@ const Calendar = (props: InferGetServerSidePropsType<typeof getServerSideProps>)
                     <IconButton size="small" onClick={offsetMonth.bind(this, true)}>
                         <ArrowForwardIosRoundedIcon />
                     </IconButton>
+                    <Box sx={{ flex: 1 }}></Box>
                 </Box>
                 <Box width="100%" display="flex" marginTop={1}>
                     {calendarHeaderList}


### PR DESCRIPTION
### Description

Added a button on the calendar view that will switch the view back to the current month, but **IT IS KINDA UGLY AND IDK WHERE ELSE TO PUT IT**

![Screenshot 2022-02-05 234949](https://user-images.githubusercontent.com/37679458/152669408-cec09658-8b76-4b10-bf67-72708442d747.jpg)

### Type of change

Delete options that do not apply:

- New feature (non-breaking change which adds functionality)

### Checklist

- [ ] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [ ] I have **fully** commented my code, especially in hard-to-understand areas
- [ ] I have made changes to the documentation OR created an issue to update documentation
- [ ] All existing functionality (if a non-breaking change) still works as it should
- [ ] I have assigned at least one person to review my pull request