### PR TITLE
Fix favicon and meta tags

### DIFF
--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -52,9 +52,30 @@ export default function MyApp(props: MyAppProps) {
     return (
         <CacheProvider value={emotionCache}>
             <Head>
-                <link rel="icon" href="/favicon.ico" />
                 <meta name="viewport" content="initial-scale=1, width=device-width" />
                 <title>TAMS Club Calendar</title>
+                <meta
+                    key="description"
+                    name="description"
+                    content="The TAMS Club Calendar is a fully contained event tracker, club/volunteering database, and general resource center. This is the unofficial club event calendar for the Texas Academy of Mathematics and Science!"
+                />
+                <meta key="title" property="og:title" content="TAMS Club Calendar" />
+                <meta key="type" property="og:type" content="website" />
+                <meta key="url" property="og:url" content="https://tams.club/" />
+                <meta key="image-0" property="og:image" content="https://cdn.tams.club/social-cover.webp" />
+                <meta key="image-1" property="og:image:width" content="1200" />
+                <meta key="image-2" property="og:image:height" content="630" />
+                <meta key="site-name" property="og:site_name" content="TAMS Club Calendar" />
+                <meta key="card" name="twitter:card" content="summary" />
+                <meta key="title-1" name="twitter:title" content="TAMS Club Calendar" />
+                <meta
+                    key="description-1"
+                    name="twitter:description"
+                    content="The TAMS Club Calendar is a fully contained event tracker, club/volunteering database, and general resource center. This is the unofficial club event calendar for the Texas Academy of Mathematics and Science!"
+                />
+                <meta key="image-3" name="twitter:image" content="https://cdn.tams.club/social-cover.webp" />
+
+                <meta key="theme-color" name="theme-color" content={theme.palette.primary.main} />
             </Head>
             <StyledEngineProvider injectFirst>
                 <ThemeProvider theme={dark ? darkTheme : theme}>

--- a/client/pages/_document.tsx
+++ b/client/pages/_document.tsx
@@ -9,28 +9,6 @@ export default class MyDocument extends Document {
         return (
             <Html lang="en">
                 <Head>
-                    <meta
-                        key="description"
-                        name="description"
-                        content="The TAMS Club Calendar is a fully contained event tracker, club/volunteering database, and general resource center. This is the unofficial club event calendar for the Texas Academy of Mathematics and Science!"
-                    />
-                    <meta key="title" property="og:title" content="TAMS Club Calendar" />
-                    <meta key="type" property="og:type" content="website" />
-                    <meta key="url" property="og:url" content="https://tams.club/" />
-                    <meta key="image-0" property="og:image" content="https://cdn.tams.club/social-cover.webp" />
-                    <meta key="image-1" property="og:image:width" content="1200" />
-                    <meta key="image-2" property="og:image:height" content="630" />
-                    <meta key="site-name" property="og:site_name" content="TAMS Club Calendar" />
-                    <meta key="card" name="twitter:card" content="summary" />
-                    <meta key="title-1" name="twitter:title" content="TAMS Club Calendar" />
-                    <meta
-                        key="description-1"
-                        name="twitter:description"
-                        content="The TAMS Club Calendar is a fully contained event tracker, club/volunteering database, and general resource center. This is the unofficial club event calendar for the Texas Academy of Mathematics and Science!"
-                    />
-                    <meta key="image-3" name="twitter:image" content="https://cdn.tams.club/social-cover.webp" />
-
-                    <meta key="theme-color" name="theme-color" content={theme.palette.primary.main} />
                     <link rel="shortcut icon" href="/favicon.ico" />
                     <link rel="apple-touch-icon" href="/android-chrome-192x192.png" />
                     <link rel="manifest" href="/manifest.json" />

--- a/client/pages/_document.tsx
+++ b/client/pages/_document.tsx
@@ -31,7 +31,7 @@ export default class MyDocument extends Document {
                     <meta key="image-3" name="twitter:image" content="https://cdn.tams.club/social-cover.webp" />
 
                     <meta key="theme-color" name="theme-color" content={theme.palette.primary.main} />
-                    <link rel="shortcut icon" href="/static/favicon.ico" />
+                    <link rel="shortcut icon" href="/favicon.ico" />
                     <link rel="apple-touch-icon" href="/android-chrome-192x192.png" />
                     <link rel="manifest" href="/manifest.json" />
                     <link rel="preconnect" href="https://fonts.gstatic.com" />

--- a/client/pages/clubs/[id].tsx
+++ b/client/pages/clubs/[id].tsx
@@ -93,8 +93,8 @@ const ClubDisplay = ({ club, error }: InferGetServerSidePropsType<typeof getServ
     if (error) {
         return (
             <PageWrapper>
-            <TitleMeta title="Clubs" path={'/clubs'} />
-            <RobotBlockMeta />
+                <TitleMeta title="Clubs" path={'/clubs'} />
+                <RobotBlockMeta />
                 <Loading error sx={{ marginBottom: 4 }}>
                     Could not get club data. Please reload the page or contact the site manager to fix this issue.
                 </Loading>

--- a/client/src/components/meta/resource-meta.tsx
+++ b/client/src/components/meta/resource-meta.tsx
@@ -31,18 +31,16 @@ const ResourceMeta = (props: ResourceMetaProps) => {
     const title =
         (props.editHistory ? '[Edit History] ' : '') +
         `${props.name} | ${capitalize(props.resource)} - TAMS Club Calendar`;
-    const [image, setImage] = useState(null);
 
-    useEffect(() => {
-        if (!props.imgSrc) return null;
-        const url = `${getCdnUrl()}/${props.imgSrc}`;
-        setImage([
-            <meta key="image-0" property="og:image" content={url} />,
-            <meta key="image-1" property="og:image:width" content="1800" />,
-            <meta key="image-2" property="og:image:height" content="750" />,
-            <meta key="image-3" name="twitter:image" content={url} />,
-        ]);
-    }, [props.imgSrc]);
+    const url = props.imgSrc ? `${getCdnUrl()}/${props.imgSrc}` : null;
+    const image = props.imgSrc
+        ? [
+              <meta key="image-0" property="og:image" content={url} />,
+              <meta key="image-1" property="og:image:width" content="1800" />,
+              <meta key="image-2" property="og:image:height" content="750" />,
+              <meta key="image-3" name="twitter:image" content={url} />,
+          ]
+        : null;
 
     return (
         <Head>


### PR DESCRIPTION
### Description

- Fixes favicon not displaying due to invalid URL in `client/pages/_document` by completely removing it, as well as other metadata, into `client/pages/_app`'s head section.
- Also fixes open graph meta tags not displaying correctly for clubs (ie. not showing club images/names) because the processing for the images was done in a `useEffect` hook for some reason, which caused it only to resolve after the component was mounted.

### Fixes #441 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request