### PR TITLE
Calendar popup now can be shown by clicking anywhere on a calendar day

### DIFF
--- a/client/src/components/calendar/calendar-day.tsx
+++ b/client/src/components/calendar/calendar-day.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import type { Dayjs } from 'dayjs';
+import { alpha } from '@mui/material/styles';
 import { darkSwitch, darkSwitchGrey } from '../../util';
 import type { Event } from '../../types';
 
@@ -7,7 +8,6 @@ import Box from '@mui/material/Box';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
 import CalendarEvent from './calendar-event';
 import CalendarPopup from './calendar-popup';
 
@@ -58,10 +58,15 @@ const CalendarDay = (props: CalendarDayPopup) => {
                     props.noRight
                         ? 'none'
                         : `1px solid ${darkSwitch(theme, theme.palette.grey[300], theme.palette.grey[700])}`,
+                cursor: 'pointer',
+                transition: '0.2s',
+                '&:hover': {
+                    backgroundColor: (theme) => darkSwitch(theme, alpha(theme.palette.grey[200], 0.9), theme.palette.grey[800]),
+                },
             }}
+            onClick={togglePopup.bind(this, true)}
         >
-            <Button
-                onClick={togglePopup.bind(this, true)}
+            <Typography
                 sx={{
                     margin: 0.5,
                     padding: 0.5,
@@ -77,7 +82,7 @@ const CalendarDay = (props: CalendarDayPopup) => {
                 }}
             >
                 {props.date.date()}
-            </Button>
+            </Typography>
             <List sx={{ paddingTop: 0 }}>
                 {activities.map((a) => (
                     <CalendarEvent activity={a} key={a.id} />

--- a/client/src/components/calendar/calendar-popup.tsx
+++ b/client/src/components/calendar/calendar-popup.tsx
@@ -30,13 +30,13 @@ const CalendarPopup = (props: CalendarPopupProps) => {
         <Dialog
             aria-labelledby="calendar-popup-title"
             open={props.open}
-            onClose={(event: {}, reason) => {
+            onClose={() => {
                 props.close();
             }}
             fullWidth
         >
             <DialogTitle id="calendar-popup-title">{`Events for ${props.date.format('MMM DD, YYYY')}`}</DialogTitle>
-            <List>
+            <List sx={{ paddingBottom: '1rem' }}>
                 {props.activities.map((e) => (
                     <CalendarEvent activity={e} key={e.id} lighter />
                 ))}


### PR DESCRIPTION
### Description

Instead of only showing the calendar popup wen the user clicks on the day number, now the calendar popup will open when the user clicks anywhere on the number. This also comes with transition and hover effects on the calendar day background.

### Fixes #377 

### Type of change

Delete options that do not apply:

- New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request