### PR TITLE
Fix calendar highlight

### DIFF
--- a/client/src/components/calendar/calendar-event.tsx
+++ b/client/src/components/calendar/calendar-event.tsx
@@ -10,9 +10,6 @@ import Link from '../shared/Link';
 interface CalendarEventProps {
     /** Event object to display */
     activity: Event;
-
-    /** True if you want the highlight color to be lighter */
-    lighter?: boolean;
 }
 
 /**

--- a/client/src/components/calendar/calendar-event.tsx
+++ b/client/src/components/calendar/calendar-event.tsx
@@ -23,6 +23,9 @@ const CalendarEvent = (props: CalendarEventProps) => {
         <ListItem sx={{ overflow: 'hidden', padding: 0 }}>
             <Link
                 href={`/events/${props.activity.id}?view=calendar`}
+                onClick={(e) => {
+                    e.stopPropagation();
+                }}
                 sx={{
                     width: '100%',
                     padding: '2px 8px',
@@ -33,9 +36,7 @@ const CalendarEvent = (props: CalendarEventProps) => {
                     transition: '0.2s',
                     '&:hover': {
                         backgroundColor: (theme: Theme) =>
-                            props.lighter
-                                ? darkSwitch(theme, theme.palette.grey[300], theme.palette.grey[700])
-                                : darkSwitch(theme, theme.palette.grey[200], theme.palette.grey[800]),
+                            darkSwitch(theme, theme.palette.grey[300], theme.palette.grey[700]),
                     },
                 }}
             >

--- a/client/src/components/calendar/calendar-popup.tsx
+++ b/client/src/components/calendar/calendar-popup.tsx
@@ -38,7 +38,7 @@ const CalendarPopup = (props: CalendarPopupProps) => {
             <DialogTitle id="calendar-popup-title">{`Events for ${props.date.format('MMM DD, YYYY')}`}</DialogTitle>
             <List sx={{ paddingBottom: '1rem' }}>
                 {props.activities.map((e) => (
-                    <CalendarEvent activity={e} key={e.id} lighter />
+                    <CalendarEvent activity={e} key={e.id} />
                 ))}
             </List>
         </Dialog>


### PR DESCRIPTION
### Description

Fixes the issue where whenever we hover over a calendar event, the background calendar event would occlude it (See below). Additionally, the calendar popup would flash briefly when opening a calendar event due to that popup being faster than a page redirect.

![image](https://user-images.githubusercontent.com/37679458/170124126-dfc2e4a8-33bc-4325-b47f-f19087afb77a.png)

^ Although hovering over the calendar day, no highlight is visible due to the calendar day highlight!

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] I have made changes to the documentation OR created an issue to update documentation
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request