### PR TITLE
Fixed calendar popup click off propagation issues

### DIFF
--- a/client/src/components/calendar/calendar-popup.tsx
+++ b/client/src/components/calendar/calendar-popup.tsx
@@ -30,8 +30,9 @@ const CalendarPopup = (props: CalendarPopupProps) => {
         <Dialog
             aria-labelledby="calendar-popup-title"
             open={props.open}
-            onClose={() => {
+            onClose={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
                 props.close();
+                e.stopPropagation();
             }}
             fullWidth
         >


### PR DESCRIPTION
### Description

Calendar popup click off does not work as the click propagates to the lower component. This is fixed with a simple `e.stopPropagation()` in the `onClose` method for the Dialog component.

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [ ] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [ ] I have **fully** commented my code, especially in hard-to-understand areas
- [ ] I have made changes to the documentation OR created an issue to update documentation
- [ ] All existing functionality (if a non-breaking change) still works as it should
- [ ] I have assigned at least one person to review my pull request