### PR TITLE
Changed link for profile icon to /profile/dashboard

### DIFF
--- a/client/src/components/menu/desktop-menu.tsx
+++ b/client/src/components/menu/desktop-menu.tsx
@@ -44,9 +44,10 @@ const DesktopMenu = (props: DesktopMenuProps) => {
 
     // Route user to profile page
     const goToProfile = () => {
+        // TODO: What do these 🍪s do?
         const cookies = new Cookies();
         cookies.remove('prev', { path: '/' });
-        router.push('/profile');
+        router.push('/profile/dashboard');
     };
 
     return (

--- a/client/src/components/menu/mobile-menu.tsx
+++ b/client/src/components/menu/mobile-menu.tsx
@@ -141,7 +141,7 @@ const MobileMenu = (props: MobileMenuProps) => {
                         </ListItemIcon>
                         <ListItemText primary="Edit" />
                     </ListItemButton>
-                    <ListItemButton component={Link} href="/profile" onClick={toggleDrawer.bind(this, false)}>
+                    <ListItemButton component={Link} href="/profile/dashboard" onClick={toggleDrawer.bind(this, false)}>
                         <ListItemIcon>
                             <AccountCircleIcon />
                         </ListItemIcon>


### PR DESCRIPTION
### Description

Profile icon now points to /profile/dashboard for logged in users; the /profile/dashboard page will redirect the user automatically to the login page if not logged in.

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request