### PR TITLE
Removed edit history items from frontend

### DIFF
--- a/client/pages/edit/clubs/[[...id]].tsx
+++ b/client/pages/edit/clubs/[[...id]].tsx
@@ -108,8 +108,7 @@ const EditClubs = ({ club, id, error, level }: InferGetServerSidePropsType<typeo
             club.coverImgThumbnail,
             club.coverImg,
             execs,
-            committees,
-            club.history
+            committees
         );
 
         // Create the club image object containing cover and exec profile picture blobs

--- a/client/pages/edit/events/[[...id]].tsx
+++ b/client/pages/edit/events/[[...id]].tsx
@@ -247,8 +247,7 @@ const EditEvents = ({ event, id, error, userId, level }: InferGetServerSideProps
             repeatsUntil,
             event.repeatOriginId,
             data.publicEvent,
-            data.reservation,
-            event.history
+            data.reservation
         );
 
         // If the event ID is null, create the event, otherwise update it

--- a/client/pages/edit/volunteering/[[...id]].tsx
+++ b/client/pages/edit/volunteering/[[...id]].tsx
@@ -70,8 +70,7 @@ const EditVolunteering = ({
             data.name,
             data.club,
             data.description,
-            createFilters(data.limited, data.semester, data.setTimes, data.weekly, data.open),
-            volunteering.history
+            createFilters(data.limited, data.semester, data.setTimes, data.weekly, data.open)
         );
 
         // Start the upload process

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -69,14 +69,11 @@ export interface Event {
 
     /** True to show on reservation calendar/check for overlaps */
     reservation: boolean;
-
-    /** Edit history list */
-    history: string[];
 }
 
 /**
  * Object to hold data for the reservation view temporarily. This is used
- * when we are displaying reservations on the reservation calendar. 
+ * when we are displaying reservations on the reservation calendar.
  */
 export interface BrokenReservation {
     /** Start time of the reservation block */
@@ -120,9 +117,6 @@ export interface Club {
 
     /** Array of committee objects */
     committees: Committee[];
-
-    /** Edit history list */
-    history: string[];
 }
 
 /** An object containing the information of an exec */
@@ -180,9 +174,6 @@ export interface Volunteering {
 
     /** Object used for filtering volunteering opportunities */
     filters: Filters;
-
-    /** Edit history list */
-    history: string[];
 }
 
 /** An object with the filters for a volunteering opportunity */
@@ -267,7 +258,7 @@ export interface HistoryItemData {
 
     /** Name of the resource */
     name: string;
-    
+
     /** List of editors' names */
     editorList: string[];
 }
@@ -293,12 +284,12 @@ export interface FetchResponse {
     data: object | null;
 }
 
-// TODO: Apply this to all POST/PUT requests and change responses to 204! 
+// TODO: Apply this to all POST/PUT requests and change responses to 204!
 /** Return object for fetch requests that only have a status */
 export type StatusResponse = {
     /** The HTTP status code */
     status: number;
-}
+};
 
 /** Link data from forms; the deleted field is for lazy deletion of input fields to simplify forms */
 export interface LinkInputData {

--- a/client/src/util.tsx
+++ b/client/src/util.tsx
@@ -365,10 +365,9 @@ export function createVolunteering(
     name: string = '',
     club: string = '',
     description: string = '',
-    filters: Filters = createFilters(),
-    history: string[] = null
+    filters: Filters = createFilters()
 ): Volunteering {
-    return { id, name, club, description, filters, history };
+    return { id, name, club, description, filters };
 }
 
 /**
@@ -383,10 +382,9 @@ export function createClub(
     coverImgThumbnail: string = '',
     coverImg: string = '',
     execs: Exec[] = [],
-    committees: Committee[] = [],
-    history: string[] = null
+    committees: Committee[] = []
 ): Club {
-    return { id, name, advised, links, description, coverImgThumbnail, coverImg, execs, committees, history };
+    return { id, name, advised, links, description, coverImgThumbnail, coverImg, execs, committees };
 }
 
 /**
@@ -453,8 +451,7 @@ export function createEvent(
     repeatsUntil: number = null,
     repeatOriginId: string = null,
     publicEvent: boolean = true,
-    reservation: boolean = false,
-    history: string[] = null
+    reservation: boolean = false
 ): Event {
     return {
         id,
@@ -474,7 +471,6 @@ export function createEvent(
         repeatOriginId,
         publicEvent,
         reservation,
-        history,
     };
 }
 


### PR DESCRIPTION
### Description

Removes history from the types and object constructor functions from frontend resources.

### Fixes #470 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request