### PR TITLE
Reservation calendar

### DIFF
--- a/client/pages/events/calendar/[[...date]].tsx
+++ b/client/pages/events/calendar/[[...date]].tsx
@@ -171,7 +171,7 @@ const Calendar = (props: InferGetServerSidePropsType<typeof getServerSideProps>)
                     {calendarHeaderList}
                 </Box>
                 {calendarDays === null ? (
-                    <Loading />
+                    <Loading sx={{ marginTop: 3 }} />
                 ) : (
                     <Box
                         sx={{

--- a/client/pages/events/calendar/[[...date]].tsx
+++ b/client/pages/events/calendar/[[...date]].tsx
@@ -82,6 +82,13 @@ const Calendar = (props: InferGetServerSidePropsType<typeof getServerSideProps>)
     const [rows, setRows] = useState(0);
     const now = dayjs(props.now);
 
+    // Adjust the offset of month when user clicks on the arrow buttons
+    // The change that is passed in will be +1 or -1 depending on which arrow button was clicked
+    const offsetMonth = (forward: boolean) => {
+        const newMonth = forward ? now.add(1, 'month') : now.subtract(1, 'month');
+        router.push(`/events/calendar/${newMonth.format('YYYY/M')}`);
+    };
+
     // Once the events are fetched, they are parsed by splitting multi-day events
     // These events are then grouped by date and each calendar day is created
     useEffect(() => {
@@ -123,13 +130,6 @@ const Calendar = (props: InferGetServerSidePropsType<typeof getServerSideProps>)
         setRows(props.numRows);
         setMonth(now.format('MMMM YYYY'));
     }, [props.activities]);
-
-    // Adjust the offset of month when user clicks on the arrow buttons
-    // The change that is passed in will be +1 or -1 depending on which arrow button was clicked
-    const offsetMonth = (forward: boolean) => {
-        const newMonth = forward ? now.add(1, 'month') : now.subtract(1, 'month');
-        router.push(`/events/calendar/${newMonth.format('YYYY/M')}`);
-    };
 
     // Create the days of the week as the header
     const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];

--- a/client/pages/events/reservations/[[...date]].tsx
+++ b/client/pages/events/reservations/[[...date]].tsx
@@ -3,7 +3,7 @@ import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
 import dayjs from 'dayjs';
 import { getReservationList } from '../../../src/api';
 import { AccessLevel, BrokenReservation } from '../../../src/types';
-import { getAccessLevel, parseDateParams } from '../../../src/util';
+import { getAccessLevel, parseDateParams, parseReservations } from '../../../src/util';
 
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
@@ -59,11 +59,12 @@ const Reservations = ({
         setWeek(dayjs());
     };
 
-    // Adjust the offset of month when user clicks on the arrow buttons
+    // Adjust the offset of week when user clicks on the arrow buttons
     // The change that is passed in will be +1 or -1 depending on which arrow button was clicked
-    const offsetMonth = (forward: boolean) => {
-        const newWeek = forward ? dayjs(now).add(1, 'week') : dayjs(now).subtract(1, 'week');
-        setWeek(newWeek);
+    const offsetWeek = (forward: boolean) => {
+        // Increment week
+        const newWeek = forward ? dayjs(week).add(1, 'week') : dayjs(week).subtract(1, 'week');
+        router.push(`/events/reservations/${newWeek.format('YYYY/M/D')}`);
     };
 
     // Scroll down to the requested day
@@ -78,79 +79,8 @@ const Reservations = ({
         // If the reservation list is null, do nothing
         if (error) return;
 
-        // Break up reservations into days and sort the reservations
-        const brokenUpReservationList: BrokenReservation[] = [];
-        reservationList.forEach((r) => {
-            // Use variable to track the current day that we are working on
-            let curr = dayjs(r.start);
-
-            // Iterate through the days until we reach the end of the reservation
-            // This is useful for splitting up reservations that span multiple days
-            while (!curr.isSame(dayjs(r.end), 'day')) {
-                // If the current hour is 23 and the "end" of the event is within the next hour, break
-                // This is to prevent events that end at midnight from appearing on the next day
-                if (curr.hour() === 23 && curr.add(1, 'hour').isSame(dayjs(r.end), 'hour')) break;
-
-                // Calculate the number of hours between the current hour and the end of the day
-                const currEnd = curr.add(1, 'day').startOf('day');
-                const currSpan = currEnd.diff(curr, 'hour');
-
-                // Create an entry for the section of the event that spans this day
-                // This entry will span the entire length of the day if it crosses over the entire day
-                // However, the span will be less than 24 if it is less than the entire day
-                brokenUpReservationList.push({ start: curr, end: currEnd, span: currSpan, data: r });
-                curr = currEnd;
-            }
-
-            // Now we calculate the number of hours between the current hour and the end of the reservation
-            // This is because the while loop will break on the last day of the reservation and we must
-            // push the last segment on manually
-            const span = dayjs(r.end).diff(curr, 'hour');
-            brokenUpReservationList.push({ start: curr, end: dayjs(r.end), span, data: r });
-        });
-
-        // The reservation list is sorted by start date
-        const sortedReservationList = brokenUpReservationList.sort((a, b) => a.start.valueOf() - b.start.valueOf());
-
-        // Create a cut reservation list that only contains reservation blocks that
-        // start at 6am or after -> this will remove all blocks between 12am and 6am
-        // and truncate blocks that start within this interval but end after
-        const cutReservationList = [];
-        sortedReservationList.forEach((r) => {
-            // If the reservation starts outside of the interval, simply add it to the list
-            if (r.start.hour() >= 6) {
-                cutReservationList.push(r);
-            } else {
-                // If the reservation starts within the 6am-12am interval,
-                // and ends after this interval, keep the block but truncate the start
-                // Otherwise we will simply ignore the block and remove it from the list
-                if (r.end.hour() >= 6 || r.end.day() !== r.start.day()) {
-                    const diff = 6 - r.start.hour();
-                    cutReservationList.push({ ...r, start: r.start.hour(6), span: r.span - diff });
-                }
-            }
-        });
-
-        // Calculate start/end dates for list
-        const start = week.startOf('week');
-        const end = start.add(7, 'day');
-
-        // Create the actual reservation components by iterating through the sorted list
-        // and incrementing days when the next event in the sorted list is on the next day
-        // This will continue to increment until the last day of the week
-        // TODO: Add a catch for an infinite loop
-        const components = [];
-        let currTime = start;
-        while (currTime.isBefore(end, 'day')) {
-            components.push(
-                <ReservationDay
-                    reservationList={cutReservationList.filter((r) => currTime.isSame(dayjs(r.start), 'day'))}
-                    date={currTime}
-                    key={currTime.valueOf()}
-                />
-            );
-            currTime = currTime.add(1, 'day');
-        }
+        // Parse the reservations by breaking up reservations and splitting them into days
+        const components = parseReservations(reservationList, week);
 
         // Update the state variable with the list of reservations
         setReservationComponentList(
@@ -204,10 +134,10 @@ const Reservations = ({
                         <TextField {...params} variant="standard" sx={{ marginLeft: { sm: 4, xs: 2 } }} />
                     )}
                 />
-                <IconButton size="small" onClick={offsetMonth.bind(this, false)} sx={{ marginLeft: 3 }}>
+                <IconButton size="small" onClick={offsetWeek.bind(this, false)} sx={{ marginLeft: 3 }}>
                     <ArrowBackIosRounded />
                 </IconButton>
-                <IconButton size="small" onClick={offsetMonth.bind(this, true)} sx={{ marginLeft: 1 }}>
+                <IconButton size="small" onClick={offsetWeek.bind(this, true)} sx={{ marginLeft: 1 }}>
                     <ArrowForwardIosRounded />
                 </IconButton>
                 <Button variant="outlined" onClick={goToToday} sx={{ mx: 3 }}>

--- a/client/pages/events/reservations/[[...date]].tsx
+++ b/client/pages/events/reservations/[[...date]].tsx
@@ -9,6 +9,9 @@ import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import DatePicker from '@mui/lab/DatePicker';
+import IconButton from '@mui/material/IconButton';
+import ArrowBackIosRounded from '@mui/icons-material/ArrowBackIosRounded';
+import ArrowForwardIosRounded from '@mui/icons-material/ArrowForwardIosRounded';
 import Loading from '../../../src/components/shared/loading';
 import ReservationDay from '../../../src/components/reservations/reservation-day';
 import AddButton from '../../../src/components/shared/add-button';
@@ -54,6 +57,19 @@ const Reservations = ({
     // Redirect the user to the current week on click
     const goToToday = () => {
         setWeek(dayjs());
+    };
+
+    // Adjust the offset of month when user clicks on the arrow buttons
+    // The change that is passed in will be +1 or -1 depending on which arrow button was clicked
+    const offsetMonth = (forward: boolean) => {
+        const newWeek = forward ? dayjs(now).add(1, 'week') : dayjs(now).subtract(1, 'week');
+        setWeek(newWeek);
+    };
+
+    // Scroll down to the requested day
+    // Index refers to the day of the week where Sunday = 0, Monday = 1, ..., Saturday = 6
+    const goToDay = (index) => {
+        window.scrollTo(0, 180 + 630 * index);
     };
 
     // When the list of reservations updates, re-render the reservation components
@@ -168,10 +184,17 @@ const Reservations = ({
         );
     }
 
+    // Create the list of buttons for the current week
+    const weekButtonList = [];
+    const start = week.startOf('week');
+    for (let i = 0; i < 7; i++) {
+        weekButtonList.push(start.add(i, 'day').format('ddd M/D'));
+    }
+
     return (
         <HomeBase noDrawer>
             <TitleMeta title="Reservations" path="/events/reservations" />
-            <Box display="flex">
+            <Box width="100%" display="flex" justifyContent="left" alignItems="center">
                 <DatePicker
                     inputFormat="[Week of] MMM D, YYYY"
                     label="Select week to show"
@@ -181,9 +204,25 @@ const Reservations = ({
                         <TextField {...params} variant="standard" sx={{ marginLeft: { sm: 4, xs: 2 } }} />
                     )}
                 />
-                <Button variant="outlined" onClick={goToToday} sx={{ mx: 2 }}>
+                <IconButton size="small" onClick={offsetMonth.bind(this, false)} sx={{ marginLeft: 3 }}>
+                    <ArrowBackIosRounded />
+                </IconButton>
+                <IconButton size="small" onClick={offsetMonth.bind(this, true)} sx={{ marginLeft: 1 }}>
+                    <ArrowForwardIosRounded />
+                </IconButton>
+                <Button variant="outlined" onClick={goToToday} sx={{ mx: 3 }}>
                     Today
                 </Button>
+                {weekButtonList.map((day, i) => (
+                    <Button
+                        variant="text"
+                        onClick={goToDay.bind(this, i)}
+                        sx={{ mx: 2, display: { lg: 'flex', md: 'none' } }}
+                        key={day}
+                    >
+                        {day}
+                    </Button>
+                ))}
             </Box>
             <AddButton color="primary" label="Event" path="/edit/events" disabled={level < AccessLevel.STANDARD} />
             {reservationComponentList === null ? <Loading /> : reservationComponentList}

--- a/client/pages/events/reservations/room/[room]/[[...date]].tsx
+++ b/client/pages/events/reservations/room/[room]/[[...date]].tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
+import { useRouter } from 'next/router';
+import dayjs from 'dayjs';
+import { getRoomReservationList } from '../../../../../src/api';
+import { parseDateParams, parseReservations } from '../../../../../src/util';
+import HomeBase from '../../../../../src/components/home/home-base';
+import TitleMeta from '../../../../../src/components/meta/title-meta';
+
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import ArrowBackIosRoundedIcon from '@mui/icons-material/ArrowBackIosRounded';
+import ArrowForwardIosRoundedIcon from '@mui/icons-material/ArrowForwardIosRounded';
+
+import data from '../../../../../src/data.json';
+
+// Server-side Rendering
+export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
+    // Extract params to get the month to use
+    const now = parseDateParams(ctx.params.date as string[]);
+
+    // Make sure room is a valid room and return error if not
+    const room = ctx.params.room as string;
+    const roomObj = data.rooms.find((r) => r.value === room);
+    if (!roomObj) {
+        return {
+            props: { now: now.valueOf(), reservationList: [], error: true },
+        };
+    }
+
+    // Get the reservations for a specific room for a given month
+    // and send an error if either fails to retrieve
+    const reservations = await getRoomReservationList(ctx.params.room as string, now.valueOf());
+
+    return {
+        props: {
+            now: now.valueOf(),
+            reservationList: reservations.data,
+            error: reservations.status !== 200,
+            room: roomObj,
+        },
+    };
+};
+
+const ReservationRoom = ({
+    now,
+    reservationList,
+    error,
+    room,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+    const router = useRouter();
+    const month = dayjs(now);
+    const [resMonthComponent, setResMonthComponent] = useState(null);
+
+    // Adjust the offset of month when user clicks on the arrow buttons
+    // The change that is passed in will be +1 or -1 depending on which arrow button was clicked
+    const offsetMonth = (forward: boolean) => {
+        const newMonth = forward ? month.add(1, 'month') : month.subtract(1, 'month');
+        router.push(`/events/reservations/room/${room.value}/${newMonth.format('YYYY/M')}`);
+    };
+
+    const back = () => {
+        router.push(`/events/reservations/${month.format('YYYY/MM/DD')}`);
+    };
+
+    // Parse fetched reservations
+    useEffect(() => {
+        if (error) return;
+
+        // Parse the reservations and save to state variable
+        setResMonthComponent(parseReservations(reservationList, month, true, room)[0]);
+    }, [reservationList]);
+
+    return (
+        <HomeBase noDrawer noActionBar>
+            <TitleMeta title={`${room.label} Reservations`} path={`/events/reservations/room/${room}`} />
+            <Typography variant="h1" sx={{ textAlign: 'center', marginTop: 2, marginBottom: 1 }}>
+                Reservations for {room.label}
+            </Typography>
+            <Button size="small" onClick={back} sx={{ margin: 'auto', marginBottom: 1 }}>
+                Back
+            </Button>
+            <Box width="100%" display="flex" justifyContent="center" alignItems="center">
+                <IconButton size="small" onClick={offsetMonth.bind(this, false)}>
+                    <ArrowBackIosRoundedIcon />
+                </IconButton>
+                <Typography variant="h1" component="h2" sx={{ width: 250, textAlign: 'center' }}>
+                    {month.format('MMMM YYYY')}
+                </Typography>
+                <IconButton size="small" onClick={offsetMonth.bind(this, true)}>
+                    <ArrowForwardIosRoundedIcon />
+                </IconButton>
+            </Box>
+            {resMonthComponent}
+        </HomeBase>
+    );
+};
+
+export default ReservationRoom;

--- a/client/pages/events/reservations/room/[room]/[[...date]].tsx
+++ b/client/pages/events/reservations/room/[room]/[[...date]].tsx
@@ -15,6 +15,7 @@ import ArrowBackIosRoundedIcon from '@mui/icons-material/ArrowBackIosRounded';
 import ArrowForwardIosRoundedIcon from '@mui/icons-material/ArrowForwardIosRounded';
 
 import data from '../../../../../src/data.json';
+import Loading from '../../../../../src/components/shared/loading';
 
 // Server-side Rendering
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
@@ -26,7 +27,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
     const roomObj = data.rooms.find((r) => r.value === room);
     if (!roomObj) {
         return {
-            props: { now: now.valueOf(), reservationList: [], error: true },
+            props: { now: now.valueOf(), reservationList: [], error: true, room: { label: '', value: '' } },
         };
     }
 
@@ -72,6 +73,20 @@ const ReservationRoom = ({
         // Parse the reservations and save to state variable
         setResMonthComponent(parseReservations(reservationList, month, true, room)[0]);
     }, [reservationList]);
+
+    // Send error if cannot get data
+    if (error) {
+        return (
+            <HomeBase noDrawer noActionBar>
+                <Loading error sx={{ marginBottom: 4 }}>
+                    Invalid room name! Please navigate back here through the reservation calendar
+                    <Button size="small" onClick={back} sx={{ margin: 'auto', marginTop: 1, display: 'block' }}>
+                        Back
+                    </Button>
+                </Loading>
+            </HomeBase>
+        );
+    }
 
     return (
         <HomeBase noDrawer noActionBar>

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -189,6 +189,10 @@ export async function getReservationList(week: number = null): Promise<ListFetch
     return getRequest(`/events/reservations/${week ? week : ''}`) as Promise<ListFetchResponse<Event>>;
 }
 
+export async function getRoomReservationList(room: string, week: number = null): Promise<ListFetchResponse<Event>> {
+    return getRequest(`/events/reservations/room/${room}/${week ? week : ''}`) as Promise<ListFetchResponse<Event>>;
+}
+
 /**
  * Creates a new event
  *

--- a/client/src/components/calendar/calendar-day.tsx
+++ b/client/src/components/calendar/calendar-day.tsx
@@ -85,7 +85,7 @@ const CalendarDay = (props: CalendarDayPopup) => {
             </Typography>
             <List sx={{ paddingTop: 0 }}>
                 {activities.map((a) => (
-                    <CalendarEvent activity={a} key={a.id} />
+                    <CalendarEvent event={a} key={a.id} />
                 ))}
                 {extraActivities === 0 ? null : (
                     <ListItem sx={{ padding: 0 }}>

--- a/client/src/components/calendar/calendar-event.tsx
+++ b/client/src/components/calendar/calendar-event.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Theme } from '@mui/material';
+import dayjs from 'dayjs';
 import { darkSwitch, darkSwitchGrey, formatEventTime } from '../../util';
 import type { Event } from '../../types';
 
@@ -9,17 +10,20 @@ import Link from '../shared/Link';
 
 interface CalendarEventProps {
     /** Event object to display */
-    activity: Event;
+    event: Event;
 }
 
 /**
  * Displays a single event in the calendar view
  */
 const CalendarEvent = (props: CalendarEventProps) => {
+    // Format the current date for url
+    const urlDate = dayjs(props.event.start).format('/YYYY/MM/DD');
+
     return (
         <ListItem sx={{ overflow: 'hidden', padding: 0 }}>
             <Link
-                href={`/events/${props.activity.id}?view=calendar`}
+                href={`/events/${props.event.id}?view=calendar${urlDate}`}
                 onClick={(e) => {
                     e.stopPropagation();
                 }}
@@ -45,7 +49,7 @@ const CalendarEvent = (props: CalendarEventProps) => {
                         fontSize: '0.65rem',
                     }}
                 >
-                    {formatEventTime(props.activity, true)}
+                    {formatEventTime(props.event, true)}
                 </Typography>
                 <Typography
                     sx={{
@@ -57,7 +61,7 @@ const CalendarEvent = (props: CalendarEventProps) => {
                         fontSize: { lg: '0.85rem', xs: '0.65rem' },
                     }}
                 >
-                    {props.activity.name}
+                    {props.event.name}
                 </Typography>
             </Link>
         </ListItem>

--- a/client/src/components/calendar/calendar-popup.tsx
+++ b/client/src/components/calendar/calendar-popup.tsx
@@ -39,7 +39,7 @@ const CalendarPopup = (props: CalendarPopupProps) => {
             <DialogTitle id="calendar-popup-title">{`Events for ${props.date.format('MMM DD, YYYY')}`}</DialogTitle>
             <List sx={{ paddingBottom: '1rem' }}>
                 {props.activities.map((e) => (
-                    <CalendarEvent activity={e} key={e.id} />
+                    <CalendarEvent event={e} key={e.id} />
                 ))}
             </List>
         </Dialog>

--- a/client/src/components/reservations/reservation-entry.tsx
+++ b/client/src/components/reservations/reservation-entry.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { alpha, Tooltip } from '@mui/material';
 import { darkSwitch, formatTime } from '../../util';
-import type { BrokenReservation } from '../../types';
+import type { BrokenReservation, Room } from '../../types';
 
 import Box from '@mui/material/Box';
 import Link from '../shared/Link';
@@ -12,6 +12,9 @@ interface ReservationEntryProps {
 
     /** Style the TableCell component */
     sx?: object;
+
+    /** If from the room page, include room object */
+    room?: Room;
 }
 
 /**
@@ -34,8 +37,9 @@ const ReservationEntry = (props: ReservationEntryProps) => {
     const endFormatted = formatTime(props.res.end.valueOf(), 'h:mma', true);
     const tooltipTitle = `${props.res.data.name} (${startFormatted} - ${endFormatted})`;
 
-    // Format the current date for url
+    // Format the current date for url and add room if defined
     const urlDate = props.res.start.format('/YYYY/MM/DD');
+    const fullUrl = props.room ? `/room/${props.room.value}/${urlDate}` : urlDate;
 
     return (
         <Box
@@ -43,7 +47,7 @@ const ReservationEntry = (props: ReservationEntryProps) => {
         >
             <Tooltip title={tooltipTitle}>
                 <Link
-                    href={`/events/${props.res.data.id}?view=reservations${urlDate}`}
+                    href={`/events/${props.res.data.id}?view=reservations${fullUrl}`}
                     sx={{
                         display: 'block',
                         fontSize: '0.75rem',

--- a/client/src/components/reservations/reservation-entry.tsx
+++ b/client/src/components/reservations/reservation-entry.tsx
@@ -1,49 +1,69 @@
 import React from 'react';
-import { alpha } from '@mui/material';
-import { darkSwitch } from '../../util';
-import type { Event } from '../../types';
+import { alpha, Tooltip } from '@mui/material';
+import { darkSwitch, formatTime } from '../../util';
+import type { BrokenReservation } from '../../types';
 
-import TableCell from '@mui/material/TableCell';
+import Box from '@mui/material/Box';
 import Link from '../shared/Link';
 
 interface ReservationEntryProps {
-    /** The reservation data object to display */
-    reservation: Event;
-
-    /** How many hours does the reservation last; this will determine the column span */
-    span: number;
+    /** Broken reservation entry */
+    res: BrokenReservation;
 
     /** Style the TableCell component */
-    sx: object;
+    sx?: object;
 }
 
 /**
- * Displays a reservation in the grid, spanning a specific number of columns.
- * This entry in the table also links to the reservation's page.
+ * Displays a reservation in the grid. This will be a certain width and
+ * be offset from the left side based on the starting hour and duration.
  */
 const ReservationEntry = (props: ReservationEntryProps) => {
+    // Calculate the offset (percentage of table width)
+    const hourStart = props.res.start.hour();
+    const minuteStart = props.res.start.minute();
+    const leftOffset = 10 + (hourStart - 6) * 5 + (5 * minuteStart) / 60;
+
+    // Calculate the width
+    const diffHour = props.res.end.diff(props.res.start, 'hour');
+    const diffMinute = props.res.end.diff(props.res.end, 'minute');
+    const width = diffHour * 5 + (5 * diffMinute) / 60;
+
+    // Format the tooltip title
+    const startFormatted = formatTime(props.res.start.valueOf(), 'h:mma', true);
+    const endFormatted = formatTime(props.res.end.valueOf(), 'h:mma', true);
+    const tooltipTitle = `${props.res.data.name} (${startFormatted} - ${endFormatted})`;
+
+    // Format the current date for url
+    const urlDate = props.res.start.format('/YYYY/MM/DD');
+
     return (
-        <TableCell colSpan={props.span || 1} sx={props.sx}>
-            <Link
-                href={`/events/${props.reservation.id}?view=reservations`}
-                sx={{
-                    display: 'block',
-                    fontSize: '0.75rem',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textAlign: 'center',
-                    textDecoration: 'none',
-                    color: 'inherit',
-                    backgroundColor: (theme) =>
-                        alpha(darkSwitch(theme, theme.palette.primary.light, theme.palette.primary.dark), 0.5),
-                    '&:hover': {
-                        textDecoration: 'underline',
-                    },
-                }}
-            >
-                {props.reservation.name}
-            </Link>
-        </TableCell>
+        <Box
+            sx={{ position: 'absolute', ...props.sx, left: `${leftOffset}%`, width: `${width}%`, alignSelf: 'center' }}
+        >
+            <Tooltip title={tooltipTitle}>
+                <Link
+                    href={`/events/${props.res.data.id}?view=reservations${urlDate}`}
+                    sx={{
+                        display: 'block',
+                        fontSize: '0.75rem',
+                        paddingLeft: 0.5,
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textAlign: 'center',
+                        textDecoration: 'none',
+                        color: 'inherit',
+                        backgroundColor: (theme) =>
+                            alpha(darkSwitch(theme, theme.palette.primary.light, theme.palette.primary.dark), 0.5),
+                        '&:hover': {
+                            textDecoration: 'underline',
+                        },
+                    }}
+                >
+                    {props.res.data.name}
+                </Link>
+            </Tooltip>
+        </Box>
     );
 };
 

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -15,7 +15,7 @@ const theme = createTheme({
             dark: '#ca9b52',
         },
         background: {
-            default: '#f3f8f5',
+            default: '#fafffa',
             paper: '#ffffff',
         },
     },

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -67,6 +67,18 @@ export interface BrokenReservation {
     data: Event;
 }
 
+/**
+ * Object to hold information for a room; this is stored
+ * in client/src/data.json
+ */
+export interface Room {
+    /** Internal id of the room */
+    value: string;
+
+    /** User-friendly label of the room */
+    label: string;
+}
+
 /** An object containing the information for a club */
 export interface Club {
     /** The unique UUIDv4 for the club */

--- a/client/src/util.tsx
+++ b/client/src/util.tsx
@@ -11,6 +11,8 @@ import {
     ExternalLink,
     TextData,
     AccessLevel,
+    BrokenReservation,
+    Room,
 } from './types';
 import type { Theme } from '@mui/material';
 import React from 'react';
@@ -22,6 +24,8 @@ import customParseFormat from 'dayjs/plugin/customParseFormat';
 import Link from './components/shared/Link';
 import { getUserById, getUserInfo } from './api';
 import { GetServerSidePropsContext } from 'next';
+import ReservationDay from './components/reservations/reservation-day';
+import ReservationMonth from './components/reservations/reservation-month';
 
 // Plugins for dayjs base library
 dayjs.extend(utc);
@@ -334,6 +338,107 @@ export function parsePublicEventList(eventList: Event[]): Event[] {
         }
     });
     return outputList.sort((a, b) => a.start - b.start);
+}
+
+/**
+ * Function to break up reservations by day and filter out reservations outside
+ * of the defined time range.
+ *
+ * @param reservationList List of reservations
+ * @param date Date to get reservations; this can be any day in the week (or month if useMonth)
+ * @param useMonth If true, will return a list of reservations within the current month
+ * @param room Room object, required if useMonth is true
+ * @returns List of ReservationDay elements for each reservation set
+ */
+export function parseReservations(
+    reservationList: Event[],
+    date: Dayjs,
+    useMonth: boolean = false,
+    room?: Room
+): JSX.Element[] {
+    // Break up reservations into days and sort the reservations
+    const brokenUpReservationList: BrokenReservation[] = [];
+    reservationList.forEach((r) => {
+        // Use variable to track the current day that we are working on
+        let curr = dayjs(r.start);
+
+        // Iterate through the days until we reach the end of the reservation
+        // This is useful for splitting up reservations that span multiple days
+        while (!curr.isSame(dayjs(r.end), 'day')) {
+            // If the current hour is 23 and the "end" of the event is within the next hour, break
+            // This is to prevent events that end at midnight from appearing on the next day
+            if (curr.hour() === 23 && curr.add(1, 'hour').isSame(dayjs(r.end), 'hour')) break;
+
+            // Calculate the number of hours between the current hour and the end of the day
+            const currEnd = curr.add(1, 'day').startOf('day');
+            const currSpan = currEnd.diff(curr, 'hour');
+
+            // Create an entry for the section of the event that spans this day
+            // This entry will span the entire length of the day if it crosses over the entire day
+            // However, the span will be less than 24 if it is less than the entire day
+            brokenUpReservationList.push({ start: curr, end: currEnd, span: currSpan, data: r });
+            curr = currEnd;
+        }
+
+        // Now we calculate the number of hours between the current hour and the end of the reservation
+        // This is because the while loop will break on the last day of the reservation and we must
+        // push the last segment on manually
+        const span = dayjs(r.end).diff(curr, 'hour');
+        brokenUpReservationList.push({ start: curr, end: dayjs(r.end), span, data: r });
+    });
+
+    // The reservation list is sorted by start date
+    const sortedReservationList = brokenUpReservationList.sort((a, b) => a.start.valueOf() - b.start.valueOf());
+
+    // Create a cut reservation list that only contains reservation blocks that
+    // start at 6am or after -> this will remove all blocks between 12am and 6am
+    // and truncate blocks that start within this interval but end after
+    const cutReservationList = [];
+    sortedReservationList.forEach((r) => {
+        // If the reservation starts outside of the interval, simply add it to the list
+        if (r.start.hour() >= 6) {
+            cutReservationList.push(r);
+        } else {
+            // If the reservation starts within the 6am-12am interval,
+            // and ends after this interval, keep the block but truncate the start
+            // Otherwise we will simply ignore the block and remove it from the list
+            if (r.end.hour() >= 6 || r.end.day() !== r.start.day()) {
+                const diff = 6 - r.start.hour();
+                cutReservationList.push({ ...r, start: r.start.hour(6), span: r.span - diff });
+            }
+        }
+    });
+
+    // If using months, there's only one ReservationMonth component
+    // This will still return an array of "components", but it will just be a single element array
+    if (useMonth) {
+        const monthStart = date.startOf('month');
+        const monthReservations = cutReservationList.filter((r) => monthStart.isSame(dayjs(r.start), 'month'));
+        return [<ReservationMonth reservationList={monthReservations} date={date} room={room} />];
+    }
+
+    // Calculate start/end dates for list
+    const start = date.startOf('week');
+    const end = start.add(7, 'day');
+
+    // Create the actual reservation components by iterating through the sorted list
+    // and incrementing days when the next event in the sorted list is on the next day
+    // This will continue to increment until the last day of the week
+    // TODO: Add a catch for an infinite loop
+    const components = [];
+    let currTime = start;
+    while (currTime.isBefore(end, 'day')) {
+        components.push(
+            <ReservationDay
+                reservationList={cutReservationList.filter((r) => currTime.isSame(dayjs(r.start), 'day'))}
+                date={currTime}
+                key={currTime.valueOf()}
+            />
+        );
+        currTime = currTime.add(1, 'day');
+    }
+
+    return components;
 }
 
 // ================== OBJECT CONSTRUCTORS =================== //

--- a/server/routes/eventsRouter.ts
+++ b/server/routes/eventsRouter.ts
@@ -108,21 +108,14 @@ router.get('/reservations/search/:location/:start/:end', async (req: Request, re
             return;
         }
 
-        // Adjust start time to be the start of the hour.
-        // For the end time, if it falls exactly on an hour, use that;
-        // otherwise, set the end time to the beginning of the next hour.
-        const startAdjusted = dayjs(start).startOf('hour').valueOf();
-        const endRoundedDown = dayjs(end).startOf('hour').valueOf();
-        const endAdjusted = end === endRoundedDown ? end : dayjs(endRoundedDown).add(1, 'hour');
-
         // Get reservation data that overlaps with the time range
         // If an event ends right on the start time or start right on the end time, it does NOT overlap
         const data = await Event.find({
             reservation: true,
             $or: [
-                { $and: [{ start: { $gte: startAdjusted } }, { start: { $lt: endAdjusted } }] },
-                { $and: [{ end: { $gt: startAdjusted } }, { end: { $lte: endAdjusted } }] },
-                { $and: [{ start: { $lte: startAdjusted } }, { end: { $gte: endAdjusted } }] },
+                { $and: [{ start: { $gte: start } }, { start: { $lt: end } }] },
+                { $and: [{ end: { $gt: start } }, { end: { $lte: end } }] },
+                { $and: [{ start: { $lte: start } }, { end: { $gte: end } }] },
             ],
             location: req.params.location,
         });

--- a/server/routes/eventsRouter.ts
+++ b/server/routes/eventsRouter.ts
@@ -78,6 +78,34 @@ router.get('/reservations/:week?', async (req: Request, res: Response) => {
 });
 
 /**
+ * GET /events/reservations/room/<room>/[month]
+ * 
+ * Sends a list of reservations for a specific room in a given month
+ * 
+ * Query parameters:
+ * - Room:  Name of room to get the event from (event.location)
+ * - Month: Month to get reservations of, should be a UTC date number
+ *          This can be any time within the month
+ */
+router.get('/reservations/room/:room/:month?', async (req: Request, res: Response) => {
+    const month = req.params.month ? dayjs(Number(req.params.month)) : dayjs();
+    try {
+        const reservations = await Event.find({
+            reservation: true,
+            location: req.params.room,
+            start: {
+                $gte: month.startOf('month').subtract(1, 'week').valueOf(),
+                $lte: month.endOf('month').add(1, 'week').valueOf(),
+            },
+        });
+        res.send(reservations);
+    } catch (error) {
+        console.error(error);
+        sendError(res, 500, 'Could not get list of reservations');
+    }
+});
+
+/**
  * GET /events/<id>
  *
  * Gets an event by id


### PR DESCRIPTION
### Description

* Replaced the reservation calendar table with absolutely positioned divs
* Lightened the color of the background for main pages on the light theme
* Reservations are no longer limited to being only on the hour and can be reserved in ANY non-overlapping time slot
* Clicking "back" on an event in the calendar will return the user to the correct calendar date
* Added buttons for each day of the week for easier scrolling down on the reservation calendar
* Created page for viewing individual room reservations

### Fixes #484 

### Type of change

Delete options that do not apply:

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request