### PR TITLE
Clicking on an edit now opens up the popup for that specific edit

### DIFF
--- a/client/pages/edit/history/[resource]/[id].tsx
+++ b/client/pages/edit/history/[resource]/[id].tsx
@@ -27,6 +27,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
     const historyRes = await getHistory(resource, id);
     const historyList = historyRes.status === 200 ? historyRes.data.history : null;
     const error = historyRes.status !== 200;
+    const editId = ctx.query.editId as string;
     return {
         props: {
             historyList: error ? [] : historyList,
@@ -35,6 +36,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
             error,
             resource,
             id,
+            editId,
         },
     };
 };
@@ -50,6 +52,7 @@ const HistoryDisplay = ({
     error,
     resource,
     id,
+    editId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
     const router = useRouter();
     const [components, setComponents] = useState(null);
@@ -88,6 +91,17 @@ const HistoryDisplay = ({
             );
         })();
     }, [historyList]);
+
+    // Open popup on load if editId is defined
+    useEffect(() => {
+        if (editId) {
+            const ind = historyList.findIndex((entry) => entry.id === editId);
+            if (ind != -1) {
+                setCurrHistory(ind);
+                setPopupOpen(true);
+            }
+        }
+    }, []);
 
     // Opens the popup for a single edit when clicked
     const openPopup = (index: React.MouseEventHandler<HTMLTableRowElement>) => {

--- a/client/pages/edit/index.tsx
+++ b/client/pages/edit/index.tsx
@@ -162,7 +162,7 @@ const Edit = ({ level }: InferGetServerSidePropsType<typeof getServerSideProps>)
                                     }}
                                     onClick={redirect.bind(
                                         this,
-                                        `/edit/history/${h.resource}/${h.resourceId}?view=list`
+                                        `/edit/history/${h.resource}/${h.resourceId}?view=list&editId=${h.id}`
                                     )}
                                 >
                                     <TableCell>{calculateEditDate(h.time)}</TableCell>


### PR DESCRIPTION
### Description

Instead of opening up a list of all edits for a given resource, clicking on a specific edit on the main edit history page opens up the popup for the specific edit.

### Fixes #454 

### Type of change

Delete options that do not apply:

- New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the coding conventions listed in [CONTRIBUTING.md](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md) OR used the Prettier VSCode extension to auto-format
- [x] I have **fully** commented my code, especially in hard-to-understand areas
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request