### PR TITLE
Fix reservation calendar width and "private event" wording

### DIFF
--- a/client/pages/edit/events/[[...id]].tsx
+++ b/client/pages/edit/events/[[...id]].tsx
@@ -405,7 +405,7 @@ const EditEvents = ({
                 <ControlledCheckbox
                     control={control}
                     name="hideEvent"
-                    label="Hide from the public calendar (This will be shown ONLY on the reservation calendar)"
+                    label="Private event (This will be shown ONLY on the reservation calendar)"
                     value={!event.publicEvent}
                     setValue={setValue}
                     sx={{ display: 'block' }}

--- a/client/src/components/reservations/reservation-entry.tsx
+++ b/client/src/components/reservations/reservation-entry.tsx
@@ -33,9 +33,8 @@ const ReservationEntry = (props: ReservationEntryProps) => {
     const leftOffset = 10 + (hourStart - 6) * 5 + (5 * minuteStart) / 60;
 
     // Calculate the width
-    const diffHour = end.diff(start, 'hour');
-    const diffMinute = end.diff(end, 'minute');
-    const width = diffHour * 5 + (5 * diffMinute) / 60;
+    const diffMinute = end.diff(start, 'minute');
+    const width = (5 * diffMinute) / 60;
 
     // Format the tooltip title
     const startFormatted = formatTime(start.valueOf(), 'h:mma', true);

--- a/client/src/data.json
+++ b/client/src/data.json
@@ -104,6 +104,22 @@
     ],
     "changelog": [
         {
+            "v": "6.1",
+            "date": "July 12, 2022",
+            "changes": [
+                "Completely rewrote the reservation calendar with divs that display finer (minute) detail on reservations",
+                "Reservations can now be made down to the minute",
+                "Fixed issue where login token cookies were not being saved",
+                "Added new colors for light theme",
+                "Added back event type with a dropdown in the edit menu",
+                "Added the ability to filter events by event type",
+                "Added a loading screen to the home page",
+                "Fixed invalid pagination on the admin page",
+                "Clicking on an edit entry on /edit will now open the popup with those specific edits",
+                "Reworded the checkbox to create a private (non-public) event"
+            ]
+        },
+        {
             "v": "6.0",
             "date": "June 13, 2022",
             "changes": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "tams-club-calendar",
     "description": "The TAMS Club Calendar is a fully contained event tracker, club/volunteering database, and general resource center. This is the unofficial club event calendar for the Texas Academy of Mathematics and Science!",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "private": true,
     "author": "Michael Zhao <michaelzhao314@gmail.com> (https://michaelzhao.xyz/)",
     "scripts": {


### PR DESCRIPTION
### Description

Fixed typo with computing width of reservation blocks on the reservation calendar.

### Fixes #509 and fixes #515 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the [coding conventions](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md#computer-coding-conventions) AND I have formatted with the prettier VSCode extension or `yarn format`
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request
