### PR TITLE
Fix formatting of event list club/type/description line

### DIFF
--- a/client/src/components/home/event-entry.tsx
+++ b/client/src/components/home/event-entry.tsx
@@ -19,9 +19,6 @@ interface EventEntryProps {
  * An event entry on the home page events list
  */
 const EventEntry = (props: EventEntryProps) => {
-    // Replace all the newlines in the description with a pipe
-    const description = `[${eventTypeToString(props.event.type)}] ` + props.event.description.replace(/\n/g, ' | ');
-
     return (
         <ListItem
             button
@@ -29,6 +26,7 @@ const EventEntry = (props: EventEntryProps) => {
                 overflowX: 'hidden',
                 padding: 0,
             }}
+            key={props.event.id}
         >
             <Link
                 href={`/events/${props.event.id}`}
@@ -81,7 +79,8 @@ const EventEntry = (props: EventEntryProps) => {
                         >
                             {props.event.club}
                         </StyledSpan>
-                        {props.event.description ? ` - ${description}` : ` - [${eventTypeToString(props.event.type)}]`}
+                        {`  ·  ${eventTypeToString(props.event.type)}` +
+                            (props.event.description ? '  ·  ' + props.event.description.replace(/\n/g, ' | ') : '')}
                     </Typography>
                 </Box>
             </Link>


### PR DESCRIPTION
### Description

Change
![image](https://user-images.githubusercontent.com/37679458/180916638-51e390c2-b569-4c41-8464-0318604b4d1e.png)

to this
![image](https://user-images.githubusercontent.com/37679458/180916655-99b8c196-9b5e-4000-b0c4-20ffe8c6a653.png)

with the description separated by another interpunct

### Type of change

Delete options that do not apply:

- New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the [coding conventions](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md#computer-coding-conventions) AND I have formatted with the prettier VSCode extension or `yarn format`
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request
