### PR TITLE
Allow club level full access to clubs and clarify add button

### DIFF
--- a/client/pages/clubs/[id].tsx
+++ b/client/pages/clubs/[id].tsx
@@ -121,7 +121,7 @@ const ClubDisplay = ({ club, error, level }: InferGetServerSidePropsType<typeof 
                     label="Club"
                     path={`/edit/clubs/${club.id}`}
                     edit
-                    disabled={level < AccessLevelEnum.CLUBS}
+                    hidden={level < AccessLevelEnum.CLUBS}
                 />
                 <Card sx={{ marginBottom: 4 }}>
                     <CardMedia

--- a/client/pages/clubs/index.tsx
+++ b/client/pages/clubs/index.tsx
@@ -90,7 +90,7 @@ const ClubList = ({ clubList, error, level }: InferGetServerSidePropsType<typeof
                     />
                     <ViewSwitcher tableView={tableView} setTableView={setTableView} />
                 </Box>
-                <AddButton color="primary" label="Club" path="/edit/clubs" hidden={level < AccessLevelEnum.ADMIN} />
+                <AddButton color="primary" label="Club" path="/edit/clubs" hidden={level < AccessLevelEnum.CLUBS} />
                 {tableView ? <ClubTable clubs={clubList} /> : clubCardList}
             </Container>
         </PageWrapper>

--- a/client/pages/edit/clubs/[[...id]].tsx
+++ b/client/pages/edit/clubs/[[...id]].tsx
@@ -172,7 +172,7 @@ const EditClubs = ({ club, id, error, level }: InferGetServerSidePropsType<typeo
                         resource="clubs"
                         id={id}
                         name={club.name}
-                        hidden={!id || level < AccessLevelEnum.ADMIN}
+                        hidden={!id || level < AccessLevelEnum.CLUBS}
                     />
                 </React.Fragment>
             ) : null}

--- a/client/pages/edit/index.tsx
+++ b/client/pages/edit/index.tsx
@@ -116,7 +116,7 @@ const Edit = ({ level }: InferGetServerSidePropsType<typeof getServerSideProps>)
                     variant="outlined"
                     onClick={add.bind(this, 'clubs')}
                     sx={{ margin: 1.5 }}
-                    disabled={level < AccessLevelEnum.ADMIN}
+                    disabled={level < AccessLevelEnum.CLUBS}
                 >
                     Add a Club
                 </Button>

--- a/client/pages/events/calendar/[[...date]].tsx
+++ b/client/pages/events/calendar/[[...date]].tsx
@@ -156,8 +156,7 @@ const Calendar = (props: InferGetServerSidePropsType<typeof getServerSideProps>)
                 <AddButton
                     color="primary"
                     label="Event"
-                    path="/edit/events"
-                    disabled={props.level < AccessLevelEnum.STANDARD}
+                    path={props.level < AccessLevelEnum.STANDARD ? "/profile?prev=/edit/events" : "/edit/events"}
                 />
                 <Box width="100%" display="flex" justifyContent="center" alignItems="center">
                     <IconButton size="small" onClick={offsetMonth.bind(this, false)}>

--- a/client/pages/events/reservations/[[...date]].tsx
+++ b/client/pages/events/reservations/[[...date]].tsx
@@ -154,7 +154,11 @@ const Reservations = ({
                     </Button>
                 ))}
             </Box>
-            <AddButton color="primary" label="Event" path="/edit/events" disabled={level < AccessLevelEnum.STANDARD} />
+            <AddButton
+                color="primary"
+                label="Event"
+                path={level < AccessLevelEnum.STANDARD ? '/profile?prev=/edit/events' : '/edit/events'}
+            />
             {reservationComponentList === null ? <Loading /> : reservationComponentList}
         </HomeBase>
     );

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -172,8 +172,7 @@ const Home = ({ eventList, error, level }: InferGetServerSidePropsType<typeof ge
                 <AddButton
                     color="primary"
                     label="Event"
-                    path="/edit/events"
-                    disabled={level < AccessLevelEnum.STANDARD}
+                    path={level < AccessLevelEnum.STANDARD ? "/profile?prev=/edit/events" : "/edit/events"}
                 />
                 <Box width="100%" marginBottom={2} display="flex" alignItems="center">
                     <Tooltip title="Filters">

--- a/client/pages/profile/index.tsx
+++ b/client/pages/profile/index.tsx
@@ -15,13 +15,15 @@ import TitleMeta from '../../src/components/meta/title-meta';
 import Popup from '../../src/components/shared/popup';
 import UploadBackdrop from '../../src/components/edit/shared/upload-backdrop';
 import { setCookie } from '../../src/util/cookies';
+import { getParams } from '../../src/util/miscUtil';
 
 // Server-side Rendering to check for token
 // TODO: This block can be cleaned up
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
     // Get the token from cookies
     const token = ctx.req.cookies.token;
-    if (token === undefined) return { props: { authorized: false } };
+    console.log(token)
+    if (token === undefined) return { props: { authorized: false, error: false } };
 
     // Check if valid token and compare with database
     const res = await getUserInfo(token);
@@ -69,8 +71,13 @@ const Login = ({ authorized, error }: InferGetServerSidePropsType<typeof getServ
         // Remove backdrop
         setBackdrop(false);
 
-        // Send user to dashboard
-        router.push('/profile/dashboard');
+        // Send user to dashboard or previous page
+        const prev = getParams('prev');
+        if (prev) {
+            router.push(prev);
+        } else {
+            router.push('/profile/dashboard');
+        }
     };
 
     const errorMessage = (response) => {
@@ -103,7 +110,7 @@ const Login = ({ authorized, error }: InferGetServerSidePropsType<typeof getServ
                         ></GoogleLogin>
                     </Box>
                     <Typography sx={{ color: (theme) => darkSwitchGrey(theme) }}>
-                        {error ? 'Error getting login page! Please check your internet and try again!' : loginText}
+                        {error ? 'Invalid token detected. Please log in again to refresh the token.' : loginText}
                     </Typography>
                 </CardContent>
             </Card>

--- a/client/pages/volunteering/[id].tsx
+++ b/client/pages/volunteering/[id].tsx
@@ -78,7 +78,7 @@ const VolunteeringDisplay = ({
                     label="Volunteering"
                     path={`/edit/volunteering/${volunteering.id}`}
                     edit
-                    disabled={level < AccessLevelEnum.CLUBS}
+                    hidden={level < AccessLevelEnum.CLUBS}
                 />
                 <Card>
                     <CardContent>

--- a/client/pages/volunteering/index.tsx
+++ b/client/pages/volunteering/index.tsx
@@ -143,7 +143,7 @@ const Volunteering = ({ volunteeringList, error, level }: InferGetServerSideProp
                     color="primary"
                     label="Volunteering"
                     path="/edit/volunteering"
-                    disabled={level < AccessLevelEnum.CLUBS}
+                    hidden={level < AccessLevelEnum.CLUBS}
                 />
                 <Box width="100%" marginBottom={2} display="flex" alignItems="center">
                     <Tooltip title="Filters">

--- a/client/src/components/edit/history/access-info.tsx
+++ b/client/src/components/edit/history/access-info.tsx
@@ -30,7 +30,7 @@ const AccessInfo = (props: AccessInfoProps) => {
     const accessInfo = [
         { l: 'Public', p: [1, 0, 0, 0, 0, 0, 0] },
         { l: 'Standard', p: [1, 1, 2, 0, 0, 0, 0] },
-        { l: 'Clubs', p: [1, 1, 2, 1, 1, 0, 2] },
+        { l: 'Clubs', p: [1, 1, 2, 1, 1, 1, 1] },
         { l: 'Admin', p: [1, 1, 1, 1, 1, 1, 1] },
     ];
 
@@ -70,9 +70,6 @@ const AccessInfo = (props: AccessInfoProps) => {
                 </TableContainer>
                 <Typography sx={{ marginTop: 3, textAlign: 'center' }}>
                     ⚠️ Events may only be modified by the users that created them ⚠️
-                </Typography>
-                <Typography sx={{ marginTop: 3, textAlign: 'center' }}>
-                    ⚠️ Clubs can only be DELETED by admins ⚠️
                 </Typography>
             </DialogContent>
         </Dialog>

--- a/client/src/components/shared/add-button.tsx
+++ b/client/src/components/shared/add-button.tsx
@@ -24,9 +24,6 @@ interface AddButtonProps {
     /** Shows the edit history button and will override all other options if true */
     editHistory?: boolean;
 
-    /** True if button should be disabled */
-    disabled?: boolean;
-
     /** True if button should be hidden */
     hidden?: boolean;
 }
@@ -59,7 +56,6 @@ const AddButton = (props: AddButtonProps) => {
                 color={props.editHistory ? 'primary' : props.color || 'default'}
                 aria-label={props.editHistory ? 'edit history' : props.edit ? 'edit' : 'add'}
                 onClick={redirectTo}
-                disabled={props.disabled}
                 sx={{
                     display: props.hidden ? 'none' : 'flex',
                     margin: props.editHistory ? '12px auto' : 'auto',

--- a/server/routes/clubsRouter.ts
+++ b/server/routes/clubsRouter.ts
@@ -49,7 +49,7 @@ const imageUpload = upload.fields([
 router.post('/', imageUpload, async (req: Request, res: Response) => {
     try {
         // Check if user is authenticated
-        if (!isAuthenticated(req, res, AccessLevelEnum.ADMIN)) return;
+        if (!isAuthenticated(req, res, AccessLevelEnum.CLUBS)) return;
 
         // Create or get IDs needed
         const id = newId();
@@ -154,7 +154,7 @@ router.put('/:id', imageUpload, async (req: Request, res: Response) => {
 router.delete('/:id', async (req: Request, res: Response) => {
     try {
         // Check if user is authenticated
-        if (!isAuthenticated(req, res, AccessLevelEnum.ADMIN)) return;
+        if (!isAuthenticated(req, res, AccessLevelEnum.CLUBS)) return;
 
         // Get club
         const club = await Club.findOne({ id: req.params.id });


### PR DESCRIPTION
### Description

* Clubs can now add/delete clubs
* Add button for events now redirects to login page

### Fixes #511 

### Type of change

Delete options that do not apply:

- New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the [coding conventions](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md#computer-coding-conventions) AND I have formatted with the prettier VSCode extension or `yarn format`
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request
