### PR TITLE
Fixed repeating events

### DIFF
--- a/client/pages/edit/events/[[...id]].tsx
+++ b/client/pages/edit/events/[[...id]].tsx
@@ -300,7 +300,7 @@ const EditEvents = ({
 
         // Not overlapping cases
         if (
-            overlaps.data.length !== 0 ||
+            overlaps.data.length === 0 ||
             overlaps.data[0].id === event.id ||
             (repeating && overlaps.data[0].repeatingId === event.repeatingId)
         ) {

--- a/client/src/components/home/event-entry.tsx
+++ b/client/src/components/home/event-entry.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Theme } from '@mui/material';
-import { eventTypeToString } from '../../util/miscUtil';
+import { eventTypeToString, locationToString } from '../../util/miscUtil';
 import { formatEventTime } from '../../util/datetime';
 import { darkSwitch } from '../../util/cssUtil';
 
@@ -18,7 +18,8 @@ interface EventEntryProps {
 /**
  * An event entry on the home page events list
  */
-const EventEntry = (props: EventEntryProps) => {
+const EventEntry = ({ event }: EventEntryProps) => {
+    const location = locationToString(event.location);
     return (
         <ListItem
             button
@@ -26,10 +27,10 @@ const EventEntry = (props: EventEntryProps) => {
                 overflowX: 'hidden',
                 padding: 0,
             }}
-            key={props.event.id}
+            key={event.id}
         >
             <Link
-                href={`/events/${props.event.id}`}
+                href={`/events/${event.id}`}
                 sx={{
                     width: '100%',
                     padding: { lg: 2, xs: '8px 0' },
@@ -48,7 +49,7 @@ const EventEntry = (props: EventEntryProps) => {
                         fontSize: { lg: '1.2rem', xs: '0.9rem' },
                     }}
                 >
-                    {`${formatEventTime(props.event)}`}
+                    {`${formatEventTime(event)}`}
                 </Typography>
                 <Box sx={{ overflow: 'hidden' }}>
                     <Typography
@@ -59,7 +60,7 @@ const EventEntry = (props: EventEntryProps) => {
                             fontSize: { lg: '1.25rem', xs: '1rem' },
                         }}
                     >
-                        {props.event.name}
+                        {event.name}
                     </Typography>
                     <Typography
                         sx={{
@@ -77,10 +78,11 @@ const EventEntry = (props: EventEntryProps) => {
                                     darkSwitch(theme, theme.palette.common.black, theme.palette.grey[400]),
                             }}
                         >
-                            {props.event.club}
+                            {event.club}
                         </StyledSpan>
-                        {`  ·  ${eventTypeToString(props.event.type)}` +
-                            (props.event.description ? '  ·  ' + props.event.description.replace(/\n/g, ' | ') : '')}
+                        {`  ·  ${eventTypeToString(event.type)}` +
+                            (location ? ` | ${location}` : '') +
+                            (event.description ? '  ·  ' + event.description.replace(/\n/g, ' | ') : '')}
                     </Typography>
                 </Box>
             </Link>

--- a/client/src/components/shared/delete-button.tsx
+++ b/client/src/components/shared/delete-button.tsx
@@ -124,7 +124,7 @@ const DeleteButton = (props: DeleteButtonProps) => {
                                     <FormControlLabel value="all" control={<Radio />} label="Delete all events" />
                                 </RadioGroup>
                             </FormControl>
-                            {repDelete && (
+                            {repDelete === 'all' && (
                                 <Alert
                                     severity="warning"
                                     sx={{

--- a/client/src/components/shared/delete-button.tsx
+++ b/client/src/components/shared/delete-button.tsx
@@ -16,6 +16,11 @@ import DialogContentText from '@mui/material/DialogContentText';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import Alert from '@mui/material/Alert';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormControl from '@mui/material/FormControl';
+import FormLabel from '@mui/material/FormLabel';
 import Popup from './popup';
 import UploadBackdrop from '../edit/shared/upload-backdrop';
 
@@ -35,11 +40,11 @@ interface DeleteButtonProps {
     /** True if button should be hidden */
     hidden?: boolean;
 
-    /** Repeating ID for the event if it repeats */
-    repeatingId?: string;
+    /** True if the event is repeating */
+    isRepeating?: boolean;
 
-    /** True if the user wants to edit all repeating instances */
-    editAll?: boolean;
+    /** Repeating ID for the event if it repeats, required if isRepeating is true */
+    repeatingId?: string;
 }
 
 /**
@@ -47,6 +52,7 @@ interface DeleteButtonProps {
  */
 const DeleteButton = (props: DeleteButtonProps) => {
     const [deletePrompt, setDeletePrompt] = useState(false);
+    const [repDelete, setRepDelete] = useState('all');
     const [popupEvent, setPopupEvent] = useState<PopupEvent>(null);
     const [backdrop, setBackdrop] = useState(false);
     const theme = useTheme();
@@ -61,7 +67,7 @@ const DeleteButton = (props: DeleteButtonProps) => {
         let res = null;
         if (props.resource === 'events') {
             res =
-                props.repeatingId && props.editAll
+                props.isRepeating && repDelete
                     ? await deleteRepeatingEvents(props.repeatingId)
                     : await deleteEvent(props.id);
         } else if (props.resource === 'clubs') {
@@ -83,6 +89,10 @@ const DeleteButton = (props: DeleteButtonProps) => {
         setBackdrop(false);
     };
 
+    const handleRepeatingRadioChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setRepDelete(e.currentTarget.value);
+    }
+
     return (
         <React.Fragment>
             <Popup event={popupEvent} />
@@ -99,15 +109,33 @@ const DeleteButton = (props: DeleteButtonProps) => {
                         Are you sure you want to delete <b>{props.name}</b>? This action is permanent and the resource
                         cannot be recovered!
                     </DialogContentText>
-                    {props.repeatingId && (
-                        <Alert
-                            severity="warning"
-                            sx={{ marginTop: 3, backgroundColor: (theme) => darkSwitch(theme, null, '#3d3a2c') }}
-                        >
-                            {props.editAll
-                                ? 'This will delete ALL repeating instances of this event! Please uncheck "Edit All Repeating Instances" if you only want to delete this instance.'
-                                : 'This will only delete THIS event and not the other repeating events. Please check "Edit All Repeating Instances" if you want to delete all repeating instances.'}
-                        </Alert>
+                    {props.isRepeating && (
+                        <React.Fragment>
+                            <FormControl sx={{ marginTop: 3 }}>
+                                <FormLabel id="delete-repeating-label">Delete Repeating Event</FormLabel>
+                                <RadioGroup
+                                    aria-labelledby="delete-repeating-label"
+                                    defaultValue="one"
+                                    name="delete-repeating"
+                                    onChange={handleRepeatingRadioChange}
+                                    value={repDelete}
+                                >
+                                    <FormControlLabel value="one" control={<Radio />} label="Delete this event" />
+                                    <FormControlLabel value="all" control={<Radio />} label="Delete all events" />
+                                </RadioGroup>
+                            </FormControl>
+                            {repDelete && (
+                                <Alert
+                                    severity="warning"
+                                    sx={{
+                                        marginTop: 3,
+                                        backgroundColor: (theme) => darkSwitch(theme, null, '#3d3a2c'),
+                                    }}
+                                >
+                                    This will delete ALL instances of this repeating event!
+                                </Alert>
+                            )}
+                        </React.Fragment>
                     )}
                 </DialogContent>
                 <DialogActions>

--- a/client/src/data.json
+++ b/client/src/data.json
@@ -130,6 +130,17 @@
     ],
     "changelog": [
         {
+            "v": "6.2.1",
+            "date": "August 11, 2022",
+            "changes": [
+                "Changed the \"editAll\" checkbox to a significantly more intuitive popup when editing repeating events",
+                "Added the ability to edit start/end times for repeating events",
+                "Added checking for overlapping events when editing repeating events",
+                "Added the \"start\" and \"end\" word to event display cards that span multiple days",
+                "Added the location to the event list"
+            ]
+        },
+        {
             "v": "6.2",
             "date": "August 9, 2022",
             "changes": [

--- a/client/src/types/event.d.ts
+++ b/client/src/types/event.d.ts
@@ -43,6 +43,9 @@ interface CalEvent {
 
     /** Repeating ID for connecting repeating events */
     repeatingId: string;
+
+    /** End repeating date for the event */
+    repeatsUntil: number;
 }
 
 /** Type of the event, can be used as filter on the event list */

--- a/client/src/util/constructors.ts
+++ b/client/src/util/constructors.ts
@@ -110,7 +110,8 @@ export function createEvent(
     noEnd: boolean = false,
     publicEvent: boolean = true,
     reservation: boolean = false,
-    repeatingId: string = null
+    repeatingId: string = null,
+    repeatsUntil: number = null,
 ): CalEvent {
     return {
         id,
@@ -127,6 +128,7 @@ export function createEvent(
         publicEvent,
         reservation,
         repeatingId,
+        repeatsUntil,
     };
 }
 

--- a/client/src/util/dataParsing.tsx
+++ b/client/src/util/dataParsing.tsx
@@ -23,8 +23,9 @@ export function parsePublicEventList(eventList: CalEvent[]): CalEvent[] {
         }
 
         // Calculate how many days the events span
+        // TODO: This still probably doesn't work with events that start/end on midnight
         let currDate = dayjs(a.start);
-        const span = dayjs(a.end).diff(currDate, 'day') + isNotMidnight(a.start) + isNotMidnight(a.end);
+        const span = dayjs(a.end).diff(currDate, 'day') + isNotMidnight(a.start);
 
         // Iterate through the days and set the display start/end times
         for (let day = 1; day <= span; day++) {

--- a/client/src/util/datetime.ts
+++ b/client/src/util/datetime.ts
@@ -98,6 +98,11 @@ export function formatEventTime(event: CalEvent, noEnd: boolean = false, checkSa
     if (!noEnd && event.start !== event.end) formattedTime += ` - ${formatTime(event.end, 'h:mma', true)}`;
     return formattedTime;
 }
+
+export function formatEventDateTime(event: CalEvent): string {
+    return formatTime(event.start, 'dddd, MMMM D, YYYY h:mma') + ' - ' + formatTime(event.end, 'dddd, MMMM D, YYYY h:mma');
+}
+
 /**
  * Calculates how long ago an edit was made, given the edit date,
  * and displays it in the most reasonable time interval

--- a/client/src/util/datetime.ts
+++ b/client/src/util/datetime.ts
@@ -66,6 +66,9 @@ export function formatDate(millis: number, format: string): string {
 export function isSameDate(first: number, second: number): boolean {
     return formatTime(first, 'MM/DD/YYYY') === formatTime(second, 'MM/DD/YYYY');
 }
+
+// TODO: The formatEventDate and formatEventTime functions are JANK -- need to refactor
+
 /**
  * Formats the full date of the event.
  * Includes an end date if not the same as the start date.
@@ -75,10 +78,8 @@ export function isSameDate(first: number, second: number): boolean {
  */
 
 export function formatEventDate(event: CalEvent): string {
-    if (!toTz(event.start).isSame(toTz(event.end), 'day')) return formatTime(event.start, 'dddd, MMMM D, YYYY h:mma');
-    let formattedTime = formatTime(event.start, 'dddd, MMMM D, YYYY');
-    if (!isSameDate(event.start, event.end)) formattedTime += formatTime(event.end, ' - dddd, MMMM D, YYYY');
-    return formattedTime;
+    if (!toTz(event.start).isSame(toTz(event.end), 'day')) return 'Start: ' + formatTime(event.start, 'dddd, MMMM D, YYYY h:mma');
+    return formatTime(event.start, 'dddd, MMMM D, YYYY');
 }
 /**
  * Formats the time of the event.
@@ -92,7 +93,7 @@ export function formatEventDate(event: CalEvent): string {
 
 export function formatEventTime(event: CalEvent, noEnd: boolean = false, checkSame: boolean = false): string {
     if (checkSame && !toTz(event.start).isSame(toTz(event.end), 'day'))
-        return formatTime(event.end, 'dddd, MMMM D, YYYY h:mma');
+        return 'End: ' + formatTime(event.end, 'dddd, MMMM D, YYYY h:mma');
 
     let formattedTime = formatTime(event.start, 'h:mma', true);
     if (!noEnd && event.start !== event.end) formattedTime += ` - ${formatTime(event.end, 'h:mma', true)}`;

--- a/client/src/util/miscUtil.tsx
+++ b/client/src/util/miscUtil.tsx
@@ -4,6 +4,8 @@ import { AccessLevelEnum } from '../types/enums';
 import { getUserInfo } from '../api';
 import { GetServerSidePropsContext } from 'next';
 
+import data from '../data.json';
+
 /**
  * Gets a query parameter given the key
  */
@@ -115,4 +117,18 @@ export function eventTypeToString(type: EventType): string {
         default:
             return 'Other';
     }
+}
+
+/**
+ * Converts a location to a string
+ *
+ * @param location Location value
+ * @return String representation of the location, or null if no location
+ */
+export function locationToString(location: string): string {
+    if (location === 'none') return null;
+
+    const room = data.rooms.find((d) => d.value === location);
+    if (room) return room.label;
+    return location;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "tams-club-calendar",
     "description": "The TAMS Club Calendar is a fully contained event tracker, club/volunteering database, and general resource center. This is the unofficial club event calendar for the Texas Academy of Mathematics and Science!",
-    "version": "6.2.0",
+    "version": "6.2.1",
     "private": true,
     "author": "Michael Zhao <michaelzhao314@gmail.com> (https://michaelzhao.xyz/)",
     "scripts": {

--- a/server/functions/edit-history.ts
+++ b/server/functions/edit-history.ts
@@ -15,7 +15,7 @@ import History from '../models/history';
  * @param editorId UUIDv4 for the ID of the user that edited the event
  * @param historyId UUIDv4 for the history object
  * @param isNew True if a new resource (default: true)
- * @param club Will use club object instead of req.body to get diff if defined
+ * @param newData Will use resource object instead of req.body to get diff if defined
  */
 export function createHistory(
     req: Request,
@@ -25,7 +25,7 @@ export function createHistory(
     editorId: string,
     historyId: string,
     isNew: boolean = true,
-    club?: ClubObject,
+    newData?: object,
 ): Document {
     // Make sure editor is valid user
     if (!editorId) return null;
@@ -37,7 +37,7 @@ export function createHistory(
         resourceId: id,
         time: new Date().valueOf(),
         editorId,
-        fields: isNew ? objectToHistoryObject(data) : getDiff(data, club || req.body),
+        fields: isNew ? objectToHistoryObject(data) : getDiff(data, newData || req.body),
     });
 }
 

--- a/server/models/event.ts
+++ b/server/models/event.ts
@@ -17,6 +17,7 @@ const eventSchema = new mongoose.Schema({
     publicEvent: Boolean,
     reservation: Boolean,
     repeatingId: String,
+    repeatsUntil: Number,
 });
 eventSchema.plugin(mongoosePaginate);
 

--- a/server/routes/eventsRouter.ts
+++ b/server/routes/eventsRouter.ts
@@ -190,6 +190,7 @@ router.post('/', async (req: Request, res: Response) => {
             publicEvent: req.body.publicEvent,
             reservation: req.body.reservation,
             repeatingId,
+            repeatsUntil: req.body.repeatsUntil,
         };
 
         // If repeating event, repeatingId will be not be null
@@ -283,6 +284,7 @@ router.put('/:id', async (req: Request, res: Response) => {
                 noEnd: req.body.noEnd,
                 publicEvent: req.body.publicEvent,
                 reservation: req.body.reservation,
+                repeatsUntil: req.body.repeatsUntil,
             };
 
             // Update events in DB
@@ -366,6 +368,7 @@ router.put('/:id', async (req: Request, res: Response) => {
             publicEvent: req.body.publicEvent,
             reservation: req.body.reservation,
             repeatingId: null,
+            repeatsUntil: null,
         };
 
         // Update or create google calendar event

--- a/server/routes/eventsRouter.ts
+++ b/server/routes/eventsRouter.ts
@@ -280,19 +280,68 @@ router.put('/:id', async (req: Request, res: Response) => {
                 club: req.body.club,
                 description: req.body.description,
                 location: req.body.location,
-                allDay: req.body.allDay,
                 noEnd: req.body.noEnd,
                 publicEvent: req.body.publicEvent,
                 reservation: req.body.reservation,
             };
 
-            // Update event in DB
+            // Update events in DB
             await Event.updateMany({ repeatingId: req.body.repeatingId }, { $set: toUpdate });
 
-            // Create and save history
-            // TODO: How do we add a history entry for each repeating event that was updated????
-            const newHistory = createHistory(req, prev, 'events', id, userId, newId(), false);
-            await newHistory.save();
+            // Retrieve all repeating events from database
+            const repeatingEvents = await Event.find({ repeatingId: req.body.repeatingId });
+
+            // Calculate the date change
+            const startChange = dayjs(req.body.start).diff(prev.start);
+            const endChange = dayjs(req.body.end).diff(prev.end);
+
+            // Iterate through all previous event objects
+            Promise.all(
+                repeatingEvents.map(async (event) => {
+                    // Update each event with its adjusted date if date was changed
+                    let adjustedStart = null;
+                    let adjustedEnd = null;
+                    if (startChange !== 0 || endChange !== 0) {
+                        adjustedStart = dayjs(event.start).add(startChange, 'ms').valueOf();
+                        adjustedEnd = dayjs(event.end).add(endChange, 'ms').valueOf();
+                    }
+
+                    // Create and save a new history for each object
+                    const toUpdateFull: EventObject = {
+                        ...toUpdate,
+                        id: event.id,
+                        eventId: event.eventId,
+                        repeatingId: event.repeatingId,
+                        start: adjustedStart,
+                        end: adjustedEnd,
+                    };
+                    const newHistory = createHistory(
+                        null,
+                        event,
+                        'events',
+                        event.id,
+                        userId,
+                        newId(),
+                        false,
+                        toUpdateFull
+                    );
+                    await newHistory.save();
+
+                    // Updates the event date fields
+                    if (adjustedStart) {
+                        event.start = adjustedStart;
+                        event.end = adjustedEnd;
+                    }
+
+                    // Updates the event in Google Calendar
+                    if (prev.publicEvent && toUpdate.publicEvent) await updateCalendar(event, event.eventId);
+                    else if (toUpdate.publicEvent) event.eventId = await addToCalendar(event);
+                    else if (prev.publicEvent && !toUpdate.publicEvent) await deleteCalendarEvent(event.eventId);
+
+                    // Save the updated event
+                    await event.save();
+                })
+            );
 
             // Send user success and return
             res.sendStatus(204);
@@ -313,7 +362,6 @@ router.put('/:id', async (req: Request, res: Response) => {
             start: Number(req.body.start),
             end: Number(req.body.end),
             location: req.body.location,
-            allDay: req.body.allDay,
             noEnd: req.body.noEnd,
             publicEvent: req.body.publicEvent,
             reservation: req.body.reservation,
@@ -323,6 +371,7 @@ router.put('/:id', async (req: Request, res: Response) => {
         // Update or create google calendar event
         if (prev.publicEvent && toUpdate.publicEvent) await updateCalendar(req.body, prev.eventId);
         else if (toUpdate.publicEvent) toUpdate.eventId = await addToCalendar(toUpdate);
+        else if (prev.publicEvent && !toUpdate.publicEvent) await deleteCalendarEvent(prev.eventId);
 
         // Update event in DB
         await Event.updateOne({ id }, { $set: toUpdate });

--- a/server/types/types.d.ts
+++ b/server/types/types.d.ts
@@ -53,6 +53,9 @@ interface EventObject {
 
     /** Repeating ID for connecting repeating events */
     repeatingId: string;
+
+    /** End repeating date for the event */
+    repeatsUntil: number;
 }
 
 /** Type of the event, can be used as filter on the event list */


### PR DESCRIPTION
### Description

* Changed the "editAll" checkbox to a significantly more intuitive popup when editing repeating events
* Added the ability to edit start/end times for repeating events
* Added checking for overlapping events when editing repeating events
* Added the "start" and "end" word to event display cards that span multiple days
* Added the location to the event list

### Fixes #539 and fixes #538 and fixes #499

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (code changes that doesn't affect functionality)

### Checklist

- [x] My code follows the [coding conventions](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md#computer-coding-conventions) AND I have formatted with the prettier VSCode extension or `yarn format`
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request
