### PR TITLE
Fixed some bugs with repeating events

### DIFF
--- a/client/pages/edit/events/[[...id]].tsx
+++ b/client/pages/edit/events/[[...id]].tsx
@@ -321,7 +321,7 @@ const EditEvents = ({
 
     // Returns the user back to the event display page
     const back = (_, addEvent = false) => {
-        const url = `/events${id ? `/${id}` : ''}`
+        const url = `/events${id ? `/${id}` : ''}`;
         if (addEvent) router.push('/events');
         else router.push(url);
     };
@@ -566,10 +566,10 @@ const EditEvents = ({
                         severity="info"
                         sx={{ my: 3, backgroundColor: (theme) => darkSwitch(theme, null, '#304249') }}
                     >
-                        This event is an instance of a repeating event. You may either choose to edit all repeating
-                        instances or just this specific event. Editing only this event will detatch the current instance
-                        from the repeating instances! This means that it will NOT be editable with the rest of the
-                        events.
+                        This event is an instance of a repeating event. After hitting submit, you may either choose to
+                        edit all repeating instances or just this specific event. Editing only this event will detatch
+                        the current instance from the repeating instances! This means that it will NOT be editable with
+                        the rest of the events.
                     </Alert>
                 )}
                 <TwoButtonBox success="Submit" onCancel={back} submit right disabled={unauthorized} />

--- a/client/pages/edit/events/[[...id]].tsx
+++ b/client/pages/edit/events/[[...id]].tsx
@@ -281,7 +281,7 @@ const EditEvents = ({
         // If the event was created successfully, redirect to the event page, otherwise display an error
         if (res.status === 204) {
             setCookie('success', !addEvent ? 'update-event' : 'add-event');
-            back(null, addEvent, true);
+            back(null, addEvent);
         } else setPopupEvent(createPopupEvent('Unable to upload data. Please refresh the page or try again.', 4));
     };
 
@@ -320,11 +320,10 @@ const EditEvents = ({
     };
 
     // Returns the user back to the event display page
-    const back = (_, addEvent = false, refresh = false) => {
+    const back = (_, addEvent = false) => {
+        const url = `/events${id ? `/${id}` : ''}`
         if (addEvent) router.push('/events');
-        else router.push(`/events${id ? `/${id}` : ''}`);
-
-        if (refresh) router.reload();
+        else router.push(url);
     };
 
     const handleRepeatingRadioChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/client/pages/events/[id].tsx
+++ b/client/pages/events/[id].tsx
@@ -4,7 +4,7 @@ import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
 import { useRouter } from 'next/router';
 import { AccessLevelEnum } from '../../src/types/enums';
 import { getParams, getAccessLevel, getTokenFromCookies, eventTypeToString } from '../../src/util/miscUtil';
-import { formatEventDate, formatEventTime } from '../../src/util/datetime';
+import { formatEventDate, formatEventTime, formatTime } from '../../src/util/datetime';
 import { darkSwitch, darkSwitchGrey } from '../../src/util/cssUtil';
 
 import Container from '@mui/material/Container';
@@ -23,7 +23,6 @@ import HomeBase from '../../src/components/home/home-base';
 import { getEvent, getUserInfo } from '../../src/api';
 
 import data from '../../src/data.json';
-import Link from '../../src/components/shared/Link';
 import ResourceMeta from '../../src/components/meta/resource-meta';
 import TitleMeta from '../../src/components/meta/title-meta';
 import RobotBlockMeta from '../../src/components/meta/robot-block-meta';
@@ -132,6 +131,11 @@ const EventDisplay = ({ event, error, level, userId }: InferGetServerSidePropsTy
                                 <Typography variant="h3" gutterBottom sx={{ fontWeight: 400 }}>
                                     {formatEventTime(event, event.noEnd, true)}
                                 </Typography>
+                                {event.repeatingId && (
+                                    <Typography sx={{ color: (theme) => darkSwitchGrey(theme) }}>
+                                        Event repeats until {formatTime(event.repeatsUntil, 'dddd, MMMM D, YYYY')}
+                                    </Typography>
+                                )}
                                 <Typography
                                     variant="h3"
                                     sx={{

--- a/server/routes/eventsRouter.ts
+++ b/server/routes/eventsRouter.ts
@@ -298,7 +298,7 @@ router.put('/:id', async (req: Request, res: Response) => {
             const endChange = dayjs(req.body.end).diff(prev.end);
 
             // Iterate through all previous event objects
-            Promise.all(
+            await Promise.all(
                 repeatingEvents.map(async (event) => {
                     // Update each event with its adjusted date if date was changed
                     let adjustedStart = null;


### PR DESCRIPTION
### Description

* Fixed issue where repeating event dates would save after success response, resulting in the user needed to reload before seeing date changes
* Added message on event card to denote a repeating event
* Clarified message when editing a repeating event that the "edit all" is chosen after hitting the submit button

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the [coding conventions](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md#computer-coding-conventions) AND I have formatted with the prettier VSCode extension or `yarn format`
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request
