### PR TITLE
Fixed positioning of reservations on mobile

### DIFF
--- a/client/src/components/reservations/reservation-day.tsx
+++ b/client/src/components/reservations/reservation-day.tsx
@@ -79,7 +79,7 @@ const ReservationDay = (props: ReservationDayProps) => {
 
             // Add the row to the table
             table.push(
-                <Box key={room.value} sx={{ display: 'flex' }}>
+                <Box key={room.value} sx={{ display: 'flex', position: 'relative' }}>
                     {row}
                 </Box>
             );


### PR DESCRIPTION
### Description

![image](https://user-images.githubusercontent.com/37679458/184929798-4d5233cd-f846-47d2-bde7-e459a2781fd0.png)

Fixes issue where reservations only span the initial screen width on mobile

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the [coding conventions](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md#computer-coding-conventions) AND I have formatted with the prettier VSCode extension or `yarn format`
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request
